### PR TITLE
feat: add monorepo architecture guard checks

### DIFF
--- a/apps/web/plugins/vite/__internal__/constants.ts
+++ b/apps/web/plugins/vite/__internal__/constants.ts
@@ -1,6 +1,21 @@
+import { createRequire } from 'node:module'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const dirname = path.dirname(new URL(import.meta.url).pathname)
-export const MANIFEST_PATH = path.resolve(dirname, '../../../../../packages/data/src/photos-manifest.json')
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
 
-export const MONOREPO_ROOT_PATH = path.resolve(dirname, '../../../../..')
+const DEFAULT_MONOREPO_ROOT_PATH = path.resolve(__dirname, '../../../../..')
+
+function resolveManifestPath(): string {
+  if (process.env.AFILMORY_MANIFEST_PATH) {
+    return path.resolve(process.env.AFILMORY_MANIFEST_PATH)
+  }
+
+  return require.resolve('@afilmory/data/manifest')
+}
+
+export const MANIFEST_PATH = resolveManifestPath()
+export const MONOREPO_ROOT_PATH = process.env.AFILMORY_MONOREPO_ROOT
+  ? path.resolve(process.env.AFILMORY_MONOREPO_ROOT)
+  : DEFAULT_MONOREPO_ROOT_PATH

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -1,5 +1,5 @@
+import type { AfilmoryManifest } from '@afilmory/data/types'
 import type { SiteConfig } from '@config'
-import type { AfilmoryManifest } from '@packages/builder/src/types/manifest'
 import type { FC, PropsWithChildren } from 'react'
 
 import type { InjectConfig } from './config/types'
@@ -32,6 +32,7 @@ declare global {
 
   interface Window {
     __SITE_CONFIG__?: Partial<SiteConfig>
+    __MANIFEST__?: AfilmoryManifest
   }
 }
 

--- a/apps/web/src/pages/(main)/photos/[photoId]/index.tsx
+++ b/apps/web/src/pages/(main)/photos/[photoId]/index.tsx
@@ -25,7 +25,7 @@ export const Component = () => {
       console.warn('[PhotoDetail] Photos array is empty or not loaded yet', {
         photosLength: photos?.length || 0,
         photoId,
-        hasManifest: typeof window !== 'undefined' && (window as any).__MANIFEST__ !== undefined,
+        hasManifest: typeof window !== 'undefined' && window.__MANIFEST__ !== undefined,
       })
       return -1
     }
@@ -117,8 +117,8 @@ export const Component = () => {
       console.error('[PhotoDetail] Photo not found:', {
         requestedPhotoId: photoId,
         photosLength: photos?.length || 0,
-        hasManifest: (window as any).__MANIFEST__ !== undefined,
-        manifestData: (window as any).__MANIFEST__ !== undefined ? (window as any).__MANIFEST__ : null,
+        hasManifest: window.__MANIFEST__ !== undefined,
+        manifestData: window.__MANIFEST__ !== undefined ? window.__MANIFEST__ : null,
         photoIds: photos?.slice(0, 10).map((p) => p?.id) || [],
       })
     }

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -1,0 +1,74 @@
+# Architecture Review & Best-Practice Optimization
+
+## Executive Summary
+
+当前仓库已经采用了相对清晰的 Monorepo 分层（`apps` + `packages`），并且将共享类型集中在 `@afilmory/data`，这是非常正确的方向。为了把这些“架构约定”从**文档约定**升级为**可执行约束**，本次优化新增了架构守卫脚本：
+
+- 自动检查 workspace 间循环依赖
+- 禁止 package 反向依赖 app
+- 强制 `@afilmory/data` 维持基础层（不可依赖其他 workspace 包）
+
+## Observed Architecture
+
+```text
+apps/web
+  └─ depends on packages/*
+
+packages/data   (foundation)
+packages/utils  (depends on data)
+packages/hooks
+packages/ui     (depends on hooks/utils)
+packages/webgl-viewer
+packages/builder(depends on data/utils)
+```
+
+这套结构符合“由下到上依赖”的最佳实践：基础层（data）→ 能力层（utils/hooks）→ 组件层（ui/webgl）→ 应用层（web）。
+
+## Risks Before Optimization
+
+1. **缺少自动化约束**
+   - 当前主要依靠团队约定来保持分层，随着包增多，容易出现“悄悄跨层依赖”。
+2. **循环依赖回归风险**
+   - 之前已完成一次循环依赖解耦，但没有持续守卫，后续改动可能引入回归。
+3. **基础层漂移风险**
+   - `@afilmory/data` 作为类型源头，应尽量稳定、零反向依赖。
+
+## Refactor / Optimization Applied
+
+### 1) Add architecture guard script
+
+新增 `scripts/check-architecture.ts`，在 CI/本地均可运行：
+
+- 扫描 `apps/*` 与 `packages/*` 的 `package.json`
+- 构建 workspace 依赖图
+- DFS 检测循环依赖
+- 检查 package -> app 的非法依赖
+- 检查 `@afilmory/data` 是否依赖其他 workspace 包
+
+### 2) Expose script in root package.json
+
+新增 npm script：
+
+```bash
+pnpm check:architecture
+```
+
+便于在 CI 或 pre-merge 阶段接入。
+
+## Recommended Next Steps
+
+1. 在 CI 中强制执行 `pnpm check:architecture`
+2. 后续可扩展规则：
+   - 强制 `apps/*` 不被其他 workspace 依赖
+   - 约束 `packages/ui` 不直接依赖 `packages/builder`
+3. 若项目继续扩展，可考虑把规则迁移到 dependency-cruiser 或 Nx graph policy。
+
+## Validation
+
+本次变更已通过：
+
+```bash
+pnpm check:architecture
+```
+
+输出：`✅ 架构检查通过`

--- a/docs/reviews/architecture-refactor-followup-review.md
+++ b/docs/reviews/architecture-refactor-followup-review.md
@@ -1,0 +1,44 @@
+# Code Review: Architecture Refactor Follow-up
+
+## Scope
+
+Review target covers the previous architecture-related changes:
+
+- Builder/Web path centralization
+- Data-layer runtime manifest decoupling
+- Architecture guard script
+- Web global type boundary updates
+
+## Findings & Decisions
+
+### 1) Architecture guard script testability
+
+- **Issue**: `scripts/check-architecture.ts` originally mixed FS scanning, validation logic, and CLI output in one file, making unit testing difficult.
+- **Risk**: Rules could regress silently because only end-to-end invocation was verifiable.
+- **Action**: Extracted pure validation logic to `scripts/check-architecture-lib.ts` and kept `scripts/check-architecture.ts` as thin IO/CLI wrapper.
+
+### 2) Data loader factory null semantics
+
+- **Issue**: `createRuntimePhotoLoader(manifest ?? resolveRuntimeManifest())` treated explicit `null` and omitted parameter the same.
+- **Risk**: Callers could not intentionally construct an empty loader when runtime manifest exists.
+- **Action**: Updated `createRuntimePhotoLoader` to distinguish:
+  - argument omitted => resolve runtime manifest,
+  - argument provided (including `null`) => use provided value.
+
+### 3) Test coverage gap
+
+- **Issue**: No unit tests for newly introduced architectural seams.
+- **Risk**: Refactor behavior (especially resolution order and layering checks) may break unnoticed.
+- **Action**: Added unit tests for:
+  - runtime manifest resolution order,
+  - photo loader domain behavior,
+  - architecture validator graph rules.
+
+## Residual Risks (Not changed in this round)
+
+1. `PhotoLoader` constructor still emits logs in test/runtime paths; could be further abstracted behind logger injection.
+2. architecture check currently scans only top-level `apps/*` and `packages/*`; nested workspace conventions would require extending scanner strategy.
+
+## Verification
+
+All new tests pass, and lint/type-check/architecture checks pass.

--- a/docs/specs/architecture-path-decoupling-spec.md
+++ b/docs/specs/architecture-path-decoupling-spec.md
@@ -1,0 +1,75 @@
+# Spec: Builder/Web 路径耦合解耦（Architecture-Level Refactor）
+
+## 1. 背景与问题定义
+
+当前代码中，Builder 与 Web 的产物路径通过硬编码字符串分散在多个模块：
+
+- `src/data/photos-manifest.json`
+- `public/thumbnails`
+- `public/originals`
+
+这会带来三个架构问题：
+
+1. **耦合过深**：Builder 逻辑直接绑定 `apps/web` 的目录结构。
+2. **可迁移性弱**：若未来 Web app 路径调整（如 `apps/site`），需要多点修改。
+3. **一致性风险**：不同模块使用不同路径来源，易产生路径漂移。
+
+## 2. 目标（Goals）
+
+- 提供 **单一来源（Single Source of Truth）** 的路径定义。
+- 支持环境变量覆盖，提升独立调试和未来迁移能力。
+- 让 Vite 插件通过包导出解析 manifest 路径，避免依赖 monorepo 相对路径。
+
+## 3. 非目标（Non-Goals）
+
+- 不调整 manifest 数据结构。
+- 不变更 builder 的业务流程（扫描、提取 EXIF、缩略图生成）。
+- 不引入新的外部依赖。
+
+## 4. 方案设计
+
+### 4.1 Builder 路径中心化
+
+在 `packages/builder/src/path.ts` 中统一导出：
+
+- `WEB_WORKDIR`
+- `MANIFEST_PATH`
+- `THUMBNAILS_DIR`
+- `ORIGINALS_DIR`
+
+并支持：
+
+- `AFILMORY_WEB_DIR` 覆盖默认 `apps/web` 路径。
+
+### 4.2 消费方改造
+
+替换各模块中的硬编码路径拼接，统一依赖路径常量：
+
+- `manifest/manager.ts`
+- `manifest/migrate.ts`
+- `image/thumbnail.ts`
+- `photo/data-processors.ts`
+- `storage/providers/eagle-provider.ts`
+- `plugins/github-repo-sync.ts`
+
+### 4.3 Web Vite 插件解耦
+
+`apps/web/plugins/vite/__internal__/constants.ts`：
+
+- `MANIFEST_PATH` 改为通过 `require.resolve('@afilmory/data/manifest')` 解析。
+- 增加 `AFILMORY_MANIFEST_PATH` 作为显式覆盖。
+- `MONOREPO_ROOT_PATH` 增加 `AFILMORY_MONOREPO_ROOT` 覆盖。
+
+## 5. 验证策略
+
+1. ESLint 校验改动文件。
+2. Builder TypeScript 编译校验。
+3. 架构守卫校验（`pnpm check:architecture`）。
+
+## 6. 回滚策略
+
+若出现路径异常，回滚至此前版本并优先检查以下环境变量是否设置错误：
+
+- `AFILMORY_WEB_DIR`
+- `AFILMORY_MANIFEST_PATH`
+- `AFILMORY_MONOREPO_ROOT`

--- a/docs/specs/data-layer-runtime-manifest-spec.md
+++ b/docs/specs/data-layer-runtime-manifest-spec.md
@@ -1,0 +1,64 @@
+# Spec: Data 层运行时 Manifest 访问重构（职责拆分 + 类型边界收敛）
+
+## 1. 背景
+
+目前 `@afilmory/data` 的 `PhotoLoader` 同时承担了三类职责：
+
+1. 运行时环境探测（`window` / 全局变量读取）
+2. Manifest 读取与容错
+3. 领域查询（按 id 查询、标签聚合、相机/镜头列表）
+
+这导致 Data 层存在以下架构问题：
+
+- **职责混杂**：环境接入逻辑与领域查询逻辑耦合在一个类构造函数中。
+- **类型边界不清晰**：大量 `any` 与 `(window as any)`，弱化了跨包类型约束。
+- **应用层反向依赖风险**：`apps/web/src/global.d.ts` 通过 builder 内部路径拿 `AfilmoryManifest` 类型，不符合“共享类型由 data 提供”的分层原则。
+
+## 2. 目标
+
+- 将“运行时 Manifest 接入”从 `PhotoLoader` 中拆出为独立模块。
+- 保留现有调用方式（`photoLoader.getPhotos()`）的兼容性。
+- 将 Web 全局类型声明收敛到 `@afilmory/data/types`，消除对 builder 内部路径的依赖。
+
+## 3. 非目标
+
+- 不改动 manifest 结构。
+- 不改动 UI 或路由行为。
+- 不引入新的运行时依赖。
+
+## 4. 设计
+
+### 4.1 新增 Runtime Manifest Source 模块
+
+新增 `packages/data/src/runtime-manifest.ts`：
+
+- 定义统一的运行时全局接口 `RuntimeManifestGlobal`。
+- 提供 `resolveRuntimeManifest()`：
+  - 按优先级读取 `window.__MANIFEST__` -> `globalThis.__MANIFEST__`。
+  - 返回强类型 `AfilmoryManifest | null`。
+
+### 4.2 拆分 PhotoLoader 领域层
+
+将 `PhotoLoader` 重构为纯领域查询对象：
+
+- 构造函数接收 `AfilmoryManifest | null`，不再直接探测环境。
+- 增加工厂函数 `createPhotoLoader(manifest?: AfilmoryManifest | null)`。
+- 默认 singleton `photoLoader` 使用 `resolveRuntimeManifest()` 生成，保持现有 API 不变。
+
+### 4.3 Web 类型边界修复
+
+`apps/web/src/global.d.ts`：
+
+- 将 `AfilmoryManifest` 类型来源由 builder 内部路径改为 `@afilmory/data/types`。
+- 声明 `Window.__MANIFEST__?: AfilmoryManifest`，减少 `any` 透传。
+
+## 5. 迁移策略
+
+- 对调用方无破坏性迁移：旧代码继续使用 `photoLoader`。
+- 新场景可逐步使用 `createPhotoLoader(...)`（例如测试或 SSR 场景注入 manifest）。
+
+## 6. 验证
+
+1. lint 相关改动文件。
+2. `apps/web` 与 `packages/data` 类型检查。
+3. `pnpm check:architecture` 验证分层规则未回退。

--- a/docs/specs/data-query-kernel-spec.md
+++ b/docs/specs/data-query-kernel-spec.md
@@ -1,0 +1,29 @@
+# Spec: Data Query Kernel Refactor (No-Behavior-Change)
+
+## Context
+
+After splitting runtime manifest resolution from `PhotoLoader`, the data layer still mixed query algorithms and side-effect outputs in a single class implementation.
+
+## Goals
+
+1. Keep runtime behavior unchanged for application callers.
+2. Further separate **query kernel** (pure functions) from **orchestration** (`PhotoLoader`).
+3. Improve deterministic testing and reduce implicit console side effects in tests.
+
+## Design
+
+- Introduce `packages/data/src/manifest-queries.ts` with pure functions:
+  - `createPhotoMap(photos)`
+  - `collectSortedTags(photos)`
+- Keep `PhotoLoader` API stable while:
+  - delegating query work to pure functions,
+  - adding optional `PhotoLoaderLogger` injection (defaults to `console`).
+- Keep `createPhotoLoader` backward compatible while supporting optional logger.
+- Add `resolveRuntimeManifestFrom(runtimeGlobal)` pure helper in runtime manifest module;
+  preserve existing `resolveRuntimeManifest()` behavior by delegating to it.
+
+## Validation
+
+- Unit tests for new query kernel.
+- Unit tests for loader behavior with injected logger.
+- Existing architecture checks and web type-check must still pass.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format": "prettier --write \"apps/**/*.{ts,tsx,js,jsx,json,css,md}\" \"packages/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "lint": "eslint --fix",
     "prepare": "simple-git-hooks",
-    "preview": "pnpm --filter @afilmory/web serve"
+    "preview": "pnpm --filter @afilmory/web serve",
+    "test:unit": "node --import tsx --test tests/unit/**/*.test.ts"
   },
   "devDependencies": {
     "@afilmory/builder": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:manifest": "BUILDER_CONFIG_PATH=builder.config.ts pnpm --filter @afilmory/builder cli",
     "build:static": "pnpm build:manifest && pnpm build:web",
     "build:web": "pnpm --filter @afilmory/web build",
+    "check:architecture": "tsx scripts/check-architecture.ts",
     "dev": "pnpm --filter @afilmory/web dev",
     "format": "prettier --write \"apps/**/*.{ts,tsx,js,jsx,json,css,md}\" \"packages/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "lint": "eslint --fix",

--- a/packages/builder/src/image/thumbnail.ts
+++ b/packages/builder/src/image/thumbnail.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { workdir } from '@afilmory/builder/path.js'
+import { THUMBNAILS_DIR } from '@afilmory/builder/path.js'
 import sharp from 'sharp'
 
 import { getGlobalLoggers } from '../photo/logger-adapter.js'
@@ -9,7 +9,7 @@ import type { ThumbnailResult } from '../types/photo.js'
 import { generateBlurhash } from './blurhash.js'
 
 // 常量定义
-const THUMBNAIL_DIR = path.join(workdir, 'public/thumbnails')
+const THUMBNAIL_DIR = THUMBNAILS_DIR
 const THUMBNAIL_QUALITY = 100
 const THUMBNAIL_WIDTH = 600
 

--- a/packages/builder/src/manifest/manager.ts
+++ b/packages/builder/src/manifest/manager.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path, { basename } from 'node:path'
 
-import { workdir } from '@afilmory/builder/path.js'
+import { MANIFEST_PATH, THUMBNAILS_DIR } from '@afilmory/builder/path.js'
 import type { _Object } from '@aws-sdk/client-s3'
 
 import { logger } from '../logger/index.js'
@@ -10,12 +10,10 @@ import type { PhotoManifestItem } from '../types/photo.js'
 import { migrateManifestFileIfNeeded } from './migrate.js'
 import { CURRENT_MANIFEST_VERSION } from './version.js'
 
-const manifestPath = path.join(workdir, 'src/data/photos-manifest.json')
-
 export async function loadExistingManifest(): Promise<AfilmoryManifest> {
   let manifest: AfilmoryManifest
   try {
-    const manifestContent = await fs.readFile(manifestPath, 'utf-8')
+    const manifestContent = await fs.readFile(MANIFEST_PATH, 'utf-8')
     manifest = JSON.parse(manifestContent) as AfilmoryManifest
   } catch {
     logger.fs.error('🔍 未找到 manifest 文件/解析失败，创建新的 manifest 文件...')
@@ -64,9 +62,9 @@ export async function saveManifest(
   // 按日期排序（最新的在前）
   const sortedManifest = [...items].sort((a, b) => new Date(b.dateTaken).getTime() - new Date(a.dateTaken).getTime())
 
-  await fs.mkdir(path.dirname(manifestPath), { recursive: true })
+  await fs.mkdir(path.dirname(MANIFEST_PATH), { recursive: true })
   await fs.writeFile(
-    manifestPath,
+    MANIFEST_PATH,
     JSON.stringify(
       {
         version: CURRENT_MANIFEST_VERSION,
@@ -79,7 +77,7 @@ export async function saveManifest(
     ),
   )
 
-  logger.fs.info(`📁 Manifest 保存至： ${manifestPath}`)
+  logger.fs.info(`📁 Manifest 保存至： ${MANIFEST_PATH}`)
   logger.fs.info(`📷 包含 ${cameras.length} 个相机，🔍 ${lenses.length} 个镜头`)
 }
 
@@ -88,20 +86,20 @@ export async function handleDeletedPhotos(items: PhotoManifestItem[]): Promise<n
   logger.main.info('🔍 检查已删除的图片...')
   if (items.length === 0) {
     // Clear all thumbnails
-    await fs.rm(path.join(workdir, 'public/thumbnails'), { recursive: true, force: true })
+    await fs.rm(THUMBNAILS_DIR, { recursive: true, force: true })
     logger.main.info('🔍 没有图片，清空缩略图...')
     return 0
   }
 
   let deletedCount = 0
-  const allThumbnails = await fs.readdir(path.join(workdir, 'public/thumbnails'))
+  const allThumbnails = await fs.readdir(THUMBNAILS_DIR)
 
   // If thumbnails not in manifest, delete it
   const manifestKeySet = new Set(items.map((item) => item.id))
 
   for (const thumbnail of allThumbnails) {
     if (!manifestKeySet.has(basename(thumbnail, '.jpg'))) {
-      await fs.unlink(path.join(workdir, 'public/thumbnails', thumbnail))
+      await fs.unlink(path.join(THUMBNAILS_DIR, thumbnail))
       deletedCount++
     }
   }

--- a/packages/builder/src/manifest/migrate.ts
+++ b/packages/builder/src/manifest/migrate.ts
@@ -1,14 +1,12 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import { workdir } from '@afilmory/builder/path.js'
+import { MANIFEST_PATH } from '@afilmory/builder/path.js'
 
 import { logger } from '../logger/index.js'
 import type { AfilmoryManifest } from '../types/manifest.js'
 import type { ManifestVersion } from './version.js'
 import { CURRENT_MANIFEST_VERSION } from './version.js'
-
-const manifestPath = path.join(workdir, 'src/data/photos-manifest.json')
 
 // Placeholder migration scaffolding (chain-of-executors)
 // Supports sequential migrations: v1 -> v2 -> v3 -> ... -> CURRENT
@@ -147,8 +145,8 @@ export async function migrateManifestFileIfNeeded(parsed: AfilmoryManifest): Pro
   try {
     if (parsed?.version === CURRENT_MANIFEST_VERSION) return null
     const migrated = migrateManifest(parsed, CURRENT_MANIFEST_VERSION)
-    await fs.mkdir(path.dirname(manifestPath), { recursive: true })
-    await fs.writeFile(manifestPath, JSON.stringify(migrated, null, 2))
+    await fs.mkdir(path.dirname(MANIFEST_PATH), { recursive: true })
+    await fs.writeFile(MANIFEST_PATH, JSON.stringify(migrated, null, 2))
     logger.main.success(`✅ Manifest 版本已更新为 ${CURRENT_MANIFEST_VERSION}`)
     return migrated
   } catch (e) {

--- a/packages/builder/src/path.ts
+++ b/packages/builder/src/path.ts
@@ -3,4 +3,22 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-export const workdir = path.resolve(__dirname, '../../../apps/web')
+function resolveFromBuilderRoot(relativePath: string): string {
+  return path.resolve(__dirname, relativePath)
+}
+
+/**
+ * Builder 生成产物所在的 Web app 根目录。
+ * 可通过环境变量覆盖，便于 monorepo 迁移或独立调试：
+ * - AFILMORY_WEB_DIR=/abs/path/to/apps/web
+ */
+export const WEB_WORKDIR = process.env.AFILMORY_WEB_DIR
+  ? path.resolve(process.env.AFILMORY_WEB_DIR)
+  : resolveFromBuilderRoot('../../../apps/web')
+
+export const MANIFEST_PATH = path.join(WEB_WORKDIR, 'src', 'data', 'photos-manifest.json')
+export const THUMBNAILS_DIR = path.join(WEB_WORKDIR, 'public', 'thumbnails')
+export const ORIGINALS_DIR = path.join(WEB_WORKDIR, 'public', 'originals')
+
+// Backward compatibility for existing imports.
+export const workdir = WEB_WORKDIR

--- a/packages/builder/src/photo/data-processors.ts
+++ b/packages/builder/src/photo/data-processors.ts
@@ -8,7 +8,7 @@ import { HEIC_FORMATS } from '../constants/index.js'
 import { extractExifData } from '../image/exif.js'
 import { calculateHistogramAndAnalyzeTone } from '../image/histogram.js'
 import { generateThumbnailAndBlurhash, thumbnailExists } from '../image/thumbnail.js'
-import { workdir } from '../path.js'
+import { THUMBNAILS_DIR } from '../path.js'
 import type { PhotoManifestItem, PickedExif, ToneAnalysis } from '../types/photo.js'
 import { getGlobalLoggers } from './logger-adapter.js'
 import type { PhotoProcessorOptions } from './processor.js'
@@ -39,7 +39,7 @@ export async function processThumbnailAndBlurhash(
     (await thumbnailExists(photoId))
   ) {
     try {
-      const thumbnailPath = path.join(workdir, 'public/thumbnails', `${photoId}.jpg`)
+      const thumbnailPath = path.join(THUMBNAILS_DIR, `${photoId}.jpg`)
       const thumbnailBuffer = await fs.readFile(thumbnailPath)
       const thumbnailUrl = `/thumbnails/${photoId}.jpg`
 

--- a/packages/builder/src/plugins/github-repo-sync.ts
+++ b/packages/builder/src/plugins/github-repo-sync.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { $ } from 'execa'
 
-import { workdir } from '../path.js'
+import { MANIFEST_PATH, THUMBNAILS_DIR, workdir } from '../path.js'
 import type { BuilderPlugin } from './types.js'
 
 const RUN_SHARED_ASSETS_DIR = 'assetsGitDir'
@@ -125,7 +125,7 @@ async function prepareRepositoryLayout({ assetsGitDir, logger }: PrepareReposito
     await fs.writeFile(manifestSourcePath, initial)
   }
 
-  const thumbnailsDir = path.resolve(workdir, 'public', 'thumbnails')
+  const thumbnailsDir = THUMBNAILS_DIR
   if (existsSync(thumbnailsDir)) {
     await $({ cwd: workdir, stdio: 'inherit' })`rm -rf ${thumbnailsDir}`
   }
@@ -134,7 +134,7 @@ async function prepareRepositoryLayout({ assetsGitDir, logger }: PrepareReposito
     stdio: 'inherit',
   })`ln -s ${thumbnailsSourceDir} ${thumbnailsDir}`
 
-  const photosManifestPath = path.resolve(workdir, 'src', 'data', 'photos-manifest.json')
+  const photosManifestPath = MANIFEST_PATH
   if (existsSync(photosManifestPath)) {
     await $({ cwd: workdir, stdio: 'inherit' })`rm -f ${photosManifestPath}`
   }

--- a/packages/builder/src/storage/providers/eagle-provider.ts
+++ b/packages/builder/src/storage/providers/eagle-provider.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { SUPPORTED_FORMATS } from '@afilmory/builder/constants/index.js'
-import { workdir } from '@afilmory/builder/path.js'
+import { ORIGINALS_DIR } from '@afilmory/builder/path.js'
 import { getGlobalLoggers } from '@afilmory/builder/photo/logger-adapter.js'
 
 import { logger } from '../../logger/index.js'
@@ -58,7 +58,7 @@ export interface EagleImageMetadata {
 const defaultEagleConfig = {
   provider: 'eagle',
   libraryPath: '',
-  distPath: path.join(workdir, 'public', 'originals'),
+  distPath: ORIGINALS_DIR,
   baseUrl: '/originals/',
   include: [],
   exclude: [],

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -2,8 +2,9 @@ import { createPhotoLoader } from './photo-loader'
 import { resolveRuntimeManifest } from './runtime-manifest'
 import type { AfilmoryManifest } from './types'
 
+export { collectSortedTags, createPhotoMap } from './manifest-queries'
 export { createPhotoLoader, PhotoLoader } from './photo-loader'
-export { resolveRuntimeManifest } from './runtime-manifest'
+export { resolveRuntimeManifest, resolveRuntimeManifestFrom } from './runtime-manifest'
 
 export const photoLoader = createPhotoLoader(resolveRuntimeManifest())
 

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -8,5 +8,9 @@ export { resolveRuntimeManifest } from './runtime-manifest'
 export const photoLoader = createPhotoLoader(resolveRuntimeManifest())
 
 export function createRuntimePhotoLoader(manifest?: AfilmoryManifest | null) {
-  return createPhotoLoader(manifest ?? resolveRuntimeManifest())
+  if (arguments.length > 0) {
+    return createPhotoLoader(manifest ?? null)
+  }
+
+  return createPhotoLoader(resolveRuntimeManifest())
 }

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,85 +1,12 @@
-import type { CameraInfo, LensInfo, PhotoManifestItem } from './types'
+import { createPhotoLoader } from './photo-loader'
+import { resolveRuntimeManifest } from './runtime-manifest'
+import type { AfilmoryManifest } from './types'
 
-class PhotoLoader {
-  private photos: PhotoManifestItem[] = []
-  private photoMap: Record<string, PhotoManifestItem> = {}
-  private cameras: CameraInfo[] = []
-  private lenses: LensInfo[] = []
+export { createPhotoLoader, PhotoLoader } from './photo-loader'
+export { resolveRuntimeManifest } from './runtime-manifest'
 
-  constructor() {
-    this.getAllTags = this.getAllTags.bind(this)
-    this.getAllCameras = this.getAllCameras.bind(this)
-    this.getAllLenses = this.getAllLenses.bind(this)
-    this.getPhotos = this.getPhotos.bind(this)
-    this.getPhoto = this.getPhoto.bind(this)
+export const photoLoader = createPhotoLoader(resolveRuntimeManifest())
 
-    try {
-      // 安全地访问 manifest 数据
-      // 首先尝试从 window 对象获取（浏览器环境）
-      let manifest: any = null
-      if (typeof window !== 'undefined' && (window as any).__MANIFEST__) {
-        manifest = (window as any).__MANIFEST__
-      } else {
-        // 回退到全局 __MANIFEST__（构建时注入的）
-        try {
-          manifest = __MANIFEST__
-        } catch {
-          // __MANIFEST__ 可能未定义，这是正常的错误处理
-        }
-      }
-
-      if (!manifest) {
-        console.error(
-          '[PhotoLoader] __MANIFEST__ is not defined. Make sure manifest-inject plugin is working correctly.',
-        )
-        this.photos = []
-        this.cameras = []
-        this.lenses = []
-        return
-      }
-
-      this.photos = (manifest?.data || []) as PhotoManifestItem[]
-      this.cameras = (manifest?.cameras || []) as CameraInfo[]
-      this.lenses = (manifest?.lenses || []) as LensInfo[]
-
-      // 构建照片映射
-      this.photos.forEach((photo) => {
-        if (photo?.id) {
-          this.photoMap[photo.id] = photo
-        }
-      })
-
-      console.info(`[PhotoLoader] Loaded ${this.photos.length} photos from manifest`)
-    } catch (error) {
-      console.error('[PhotoLoader] Failed to initialize:', error)
-      this.photos = []
-      this.cameras = []
-      this.lenses = []
-    }
-  }
-
-  getPhotos() {
-    return this.photos
-  }
-
-  getPhoto(id: string) {
-    return this.photoMap[id]
-  }
-
-  getAllTags() {
-    const tagSet = new Set<string>()
-    this.photos.forEach((photo) => {
-      photo.tags.forEach((tag) => tagSet.add(tag))
-    })
-    return Array.from(tagSet).sort()
-  }
-
-  getAllCameras() {
-    return this.cameras
-  }
-
-  getAllLenses() {
-    return this.lenses
-  }
+export function createRuntimePhotoLoader(manifest?: AfilmoryManifest | null) {
+  return createPhotoLoader(manifest ?? resolveRuntimeManifest())
 }
-export const photoLoader = new PhotoLoader()

--- a/packages/data/src/manifest-queries.ts
+++ b/packages/data/src/manifest-queries.ts
@@ -1,12 +1,15 @@
 import type { PhotoManifestItem } from './types'
 
 export function createPhotoMap(photos: PhotoManifestItem[]): Record<string, PhotoManifestItem> {
-  return photos.reduce<Record<string, PhotoManifestItem>>((acc, photo) => {
-    if (photo?.id) {
-      acc[photo.id] = photo
-    }
-    return acc
-  }, {})
+  return photos.reduce<Record<string, PhotoManifestItem>>(
+    (acc, photo) => {
+      if (photo?.id) {
+        acc[photo.id] = photo
+      }
+      return acc
+    },
+    Object.create(null) as Record<string, PhotoManifestItem>,
+  )
 }
 
 export function collectSortedTags(photos: PhotoManifestItem[]): string[] {

--- a/packages/data/src/manifest-queries.ts
+++ b/packages/data/src/manifest-queries.ts
@@ -1,0 +1,21 @@
+import type { PhotoManifestItem } from './types'
+
+export function createPhotoMap(photos: PhotoManifestItem[]): Record<string, PhotoManifestItem> {
+  return photos.reduce<Record<string, PhotoManifestItem>>((acc, photo) => {
+    if (photo?.id) {
+      acc[photo.id] = photo
+    }
+    return acc
+  }, {})
+}
+
+export function collectSortedTags(photos: PhotoManifestItem[]): string[] {
+  const tagSet = new Set<string>()
+  for (const photo of photos) {
+    for (const tag of photo.tags) {
+      tagSet.add(tag)
+    }
+  }
+
+  return [...tagSet].sort()
+}

--- a/packages/data/src/photo-loader.ts
+++ b/packages/data/src/photo-loader.ts
@@ -1,0 +1,59 @@
+import type { AfilmoryManifest, CameraInfo, LensInfo, PhotoManifestItem } from './types'
+
+export class PhotoLoader {
+  private readonly photos: PhotoManifestItem[]
+  private readonly photoMap: Record<string, PhotoManifestItem>
+  private readonly cameras: CameraInfo[]
+  private readonly lenses: LensInfo[]
+
+  constructor(manifest: AfilmoryManifest | null) {
+    this.photos = manifest?.data ?? []
+    this.cameras = manifest?.cameras ?? []
+    this.lenses = manifest?.lenses ?? []
+
+    this.photoMap = this.photos.reduce<Record<string, PhotoManifestItem>>((acc, photo) => {
+      if (photo?.id) {
+        acc[photo.id] = photo
+      }
+      return acc
+    }, {})
+
+    if (!manifest) {
+      console.error('[PhotoLoader] __MANIFEST__ is not defined. Make sure manifest-inject plugin is working correctly.')
+      return
+    }
+
+    console.info(`[PhotoLoader] Loaded ${this.photos.length} photos from manifest`)
+  }
+
+  getPhotos(): PhotoManifestItem[] {
+    return this.photos
+  }
+
+  getPhoto(id: string): PhotoManifestItem | undefined {
+    return this.photoMap[id]
+  }
+
+  getAllTags(): string[] {
+    const tagSet = new Set<string>()
+    for (const photo of this.photos) {
+      for (const tag of photo.tags) {
+        tagSet.add(tag)
+      }
+    }
+
+    return [...tagSet].sort()
+  }
+
+  getAllCameras(): CameraInfo[] {
+    return this.cameras
+  }
+
+  getAllLenses(): LensInfo[] {
+    return this.lenses
+  }
+}
+
+export function createPhotoLoader(manifest: AfilmoryManifest | null): PhotoLoader {
+  return new PhotoLoader(manifest)
+}

--- a/packages/data/src/photo-loader.ts
+++ b/packages/data/src/photo-loader.ts
@@ -1,4 +1,9 @@
+import { collectSortedTags, createPhotoMap } from './manifest-queries'
 import type { AfilmoryManifest, CameraInfo, LensInfo, PhotoManifestItem } from './types'
+
+export type PhotoLoaderLogger = Pick<typeof console, 'error' | 'info'>
+
+const defaultPhotoLoaderLogger: PhotoLoaderLogger = console
 
 export class PhotoLoader {
   private readonly photos: PhotoManifestItem[]
@@ -6,24 +11,23 @@ export class PhotoLoader {
   private readonly cameras: CameraInfo[]
   private readonly lenses: LensInfo[]
 
-  constructor(manifest: AfilmoryManifest | null) {
+  constructor(
+    manifest: AfilmoryManifest | null,
+    private readonly logger: PhotoLoaderLogger = defaultPhotoLoaderLogger,
+  ) {
     this.photos = manifest?.data ?? []
     this.cameras = manifest?.cameras ?? []
     this.lenses = manifest?.lenses ?? []
-
-    this.photoMap = this.photos.reduce<Record<string, PhotoManifestItem>>((acc, photo) => {
-      if (photo?.id) {
-        acc[photo.id] = photo
-      }
-      return acc
-    }, {})
+    this.photoMap = createPhotoMap(this.photos)
 
     if (!manifest) {
-      console.error('[PhotoLoader] __MANIFEST__ is not defined. Make sure manifest-inject plugin is working correctly.')
+      this.logger.error(
+        '[PhotoLoader] __MANIFEST__ is not defined. Make sure manifest-inject plugin is working correctly.',
+      )
       return
     }
 
-    console.info(`[PhotoLoader] Loaded ${this.photos.length} photos from manifest`)
+    this.logger.info(`[PhotoLoader] Loaded ${this.photos.length} photos from manifest`)
   }
 
   getPhotos(): PhotoManifestItem[] {
@@ -35,14 +39,7 @@ export class PhotoLoader {
   }
 
   getAllTags(): string[] {
-    const tagSet = new Set<string>()
-    for (const photo of this.photos) {
-      for (const tag of photo.tags) {
-        tagSet.add(tag)
-      }
-    }
-
-    return [...tagSet].sort()
+    return collectSortedTags(this.photos)
   }
 
   getAllCameras(): CameraInfo[] {
@@ -54,6 +51,6 @@ export class PhotoLoader {
   }
 }
 
-export function createPhotoLoader(manifest: AfilmoryManifest | null): PhotoLoader {
-  return new PhotoLoader(manifest)
+export function createPhotoLoader(manifest: AfilmoryManifest | null, logger?: PhotoLoaderLogger): PhotoLoader {
+  return new PhotoLoader(manifest, logger)
 }

--- a/packages/data/src/runtime-manifest.ts
+++ b/packages/data/src/runtime-manifest.ts
@@ -1,0 +1,21 @@
+import type { AfilmoryManifest } from './types'
+
+type RuntimeManifestGlobal = typeof globalThis & {
+  __MANIFEST__?: AfilmoryManifest
+  window?: {
+    __MANIFEST__?: AfilmoryManifest
+  }
+}
+
+function readFromWindow(runtimeGlobal: RuntimeManifestGlobal): AfilmoryManifest | null {
+  return runtimeGlobal.window?.__MANIFEST__ ?? null
+}
+
+function readFromGlobalThis(runtimeGlobal: RuntimeManifestGlobal): AfilmoryManifest | null {
+  return runtimeGlobal.__MANIFEST__ ?? null
+}
+
+export function resolveRuntimeManifest(): AfilmoryManifest | null {
+  const runtimeGlobal = globalThis as RuntimeManifestGlobal
+  return readFromWindow(runtimeGlobal) ?? readFromGlobalThis(runtimeGlobal)
+}

--- a/packages/data/src/runtime-manifest.ts
+++ b/packages/data/src/runtime-manifest.ts
@@ -1,6 +1,6 @@
 import type { AfilmoryManifest } from './types'
 
-type RuntimeManifestGlobal = typeof globalThis & {
+export type RuntimeManifestGlobal = typeof globalThis & {
   __MANIFEST__?: AfilmoryManifest
   window?: {
     __MANIFEST__?: AfilmoryManifest
@@ -15,7 +15,10 @@ function readFromGlobalThis(runtimeGlobal: RuntimeManifestGlobal): AfilmoryManif
   return runtimeGlobal.__MANIFEST__ ?? null
 }
 
-export function resolveRuntimeManifest(): AfilmoryManifest | null {
-  const runtimeGlobal = globalThis as RuntimeManifestGlobal
+export function resolveRuntimeManifestFrom(runtimeGlobal: RuntimeManifestGlobal): AfilmoryManifest | null {
   return readFromWindow(runtimeGlobal) ?? readFromGlobalThis(runtimeGlobal)
+}
+
+export function resolveRuntimeManifest(): AfilmoryManifest | null {
+  return resolveRuntimeManifestFrom(globalThis as RuntimeManifestGlobal)
 }

--- a/scripts/check-architecture-lib.ts
+++ b/scripts/check-architecture-lib.ts
@@ -1,0 +1,93 @@
+export type WorkspaceType = 'app' | 'package'
+
+export type WorkspaceNode = {
+  name: string
+  dir: string
+  type: WorkspaceType
+  deps: string[]
+}
+
+export function buildWorkspaceGraph(nodes: WorkspaceNode[]): Map<string, string[]> {
+  const workspaceNames = new Set(nodes.map((n) => n.name))
+  const graph = new Map<string, string[]>()
+
+  for (const node of nodes) {
+    graph.set(
+      node.name,
+      node.deps.filter((dep) => workspaceNames.has(dep)),
+    )
+  }
+
+  return graph
+}
+
+export function detectCycles(graph: Map<string, string[]>): string[][] {
+  const cycles: string[][] = []
+  const visited = new Set<string>()
+  const inStack = new Set<string>()
+  const stack: string[] = []
+
+  const dfs = (node: string): void => {
+    visited.add(node)
+    inStack.add(node)
+    stack.push(node)
+
+    for (const next of graph.get(node) ?? []) {
+      if (!visited.has(next)) {
+        dfs(next)
+        continue
+      }
+
+      if (inStack.has(next)) {
+        const cycleStart = stack.lastIndexOf(next)
+        if (cycleStart !== -1) {
+          const cycle = [...stack.slice(cycleStart), next]
+          const signature = cycle.join(' -> ')
+          const exists = cycles.some((item) => item.join(' -> ') === signature)
+          if (!exists) {
+            cycles.push(cycle)
+          }
+        }
+      }
+    }
+
+    stack.pop()
+    inStack.delete(node)
+  }
+
+  for (const node of graph.keys()) {
+    if (!visited.has(node)) dfs(node)
+  }
+
+  return cycles
+}
+
+export function validateArchitecture(nodes: WorkspaceNode[]): string[] {
+  const graph = buildWorkspaceGraph(nodes)
+  const errors: string[] = []
+
+  for (const cycle of detectCycles(graph)) {
+    errors.push(`发现循环依赖: ${cycle.join(' -> ')}`)
+  }
+
+  const nodeMap = new Map(nodes.map((node) => [node.name, node]))
+
+  for (const node of nodes) {
+    for (const dep of graph.get(node.name) ?? []) {
+      const target = nodeMap.get(dep)
+      if (!target) continue
+
+      if (node.type === 'package' && target.type === 'app') {
+        errors.push(`非法依赖: 包 ${node.name} 不能依赖应用 ${target.name}`)
+      }
+    }
+  }
+
+  const dataPackage = '@afilmory/data'
+  const dataDeps = graph.get(dataPackage) ?? []
+  if (dataDeps.length > 0) {
+    errors.push(`分层约束: ${dataPackage} 应处于基础层，不能依赖其他 workspace 包: ${dataDeps.join(', ')}`)
+  }
+
+  return errors
+}

--- a/scripts/check-architecture.ts
+++ b/scripts/check-architecture.ts
@@ -13,6 +13,10 @@ const readJson = async <T>(filePath: string): Promise<T> => {
   return JSON.parse(content) as T
 }
 
+function isMissingPackageJsonError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
 async function getWorkspaceNodes(): Promise<WorkspaceNode[]> {
   const nodes: WorkspaceNode[] = []
 
@@ -47,8 +51,12 @@ async function getWorkspaceNodes(): Promise<WorkspaceNode[]> {
           type,
           deps: Object.keys(allDeps ?? {}),
         })
-      } catch {
-        // Ignore directories without package.json
+      } catch (error) {
+        if (isMissingPackageJsonError(error)) {
+          continue
+        }
+
+        throw error
       }
     }
   }

--- a/scripts/check-architecture.ts
+++ b/scripts/check-architecture.ts
@@ -1,24 +1,19 @@
 import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { WorkspaceNode, WorkspaceType } from './check-architecture-lib.js'
+import { validateArchitecture } from './check-architecture-lib.js'
 
 const rootDir = process.cwd()
 const workspaceDirs = ['apps', 'packages']
-
-type WorkspaceType = 'app' | 'package'
-
-type WorkspaceNode = {
-  name: string
-  dir: string
-  type: WorkspaceType
-  deps: string[]
-}
 
 const readJson = async <T>(filePath: string): Promise<T> => {
   const content = await readFile(filePath, 'utf8')
   return JSON.parse(content) as T
 }
 
-const getWorkspaceNodes = async (): Promise<WorkspaceNode[]> => {
+async function getWorkspaceNodes(): Promise<WorkspaceNode[]> {
   const nodes: WorkspaceNode[] = []
 
   for (const workspaceDir of workspaceDirs) {
@@ -61,97 +56,27 @@ const getWorkspaceNodes = async (): Promise<WorkspaceNode[]> => {
   return nodes
 }
 
-const detectCycles = (graph: Map<string, string[]>): string[][] => {
-  const cycles: string[][] = []
-  const visited = new Set<string>()
-  const inStack = new Set<string>()
-  const stack: string[] = []
-
-  const dfs = (node: string): void => {
-    visited.add(node)
-    inStack.add(node)
-    stack.push(node)
-
-    for (const next of graph.get(node) ?? []) {
-      if (!visited.has(next)) {
-        dfs(next)
-        continue
-      }
-
-      if (inStack.has(next)) {
-        const cycleStart = stack.lastIndexOf(next)
-        if (cycleStart !== -1) {
-          const cycle = [...stack.slice(cycleStart), next]
-          const signature = cycle.join(' -> ')
-          const exists = cycles.some((item) => item.join(' -> ') === signature)
-          if (!exists) {
-            cycles.push(cycle)
-          }
-        }
-      }
-    }
-
-    stack.pop()
-    inStack.delete(node)
-  }
-
-  for (const node of graph.keys()) {
-    if (!visited.has(node)) dfs(node)
-  }
-
-  return cycles
-}
-
-const main = async (): Promise<void> => {
+export async function runArchitectureCheck(): Promise<number> {
   const nodes = await getWorkspaceNodes()
-  const workspaceNames = new Set(nodes.map((n) => n.name))
-
-  const graph = new Map<string, string[]>()
-  for (const node of nodes) {
-    graph.set(
-      node.name,
-      node.deps.filter((dep) => workspaceNames.has(dep)),
-    )
-  }
-
-  const errors: string[] = []
-
-  const cycles = detectCycles(graph)
-  for (const cycle of cycles) {
-    errors.push(`发现循环依赖: ${cycle.join(' -> ')}`)
-  }
-
-  const nodeMap = new Map(nodes.map((node) => [node.name, node]))
-
-  for (const node of nodes) {
-    for (const dep of graph.get(node.name) ?? []) {
-      const target = nodeMap.get(dep)
-      if (!target) continue
-
-      if (node.type === 'package' && target.type === 'app') {
-        errors.push(`非法依赖: 包 ${node.name} 不能依赖应用 ${target.name}`)
-      }
-    }
-  }
-
-  const dataPackage = '@afilmory/data'
-  const dataDeps = graph.get(dataPackage) ?? []
-  if (dataDeps.length > 0) {
-    errors.push(`分层约束: ${dataPackage} 应处于基础层，不能依赖其他 workspace 包: ${dataDeps.join(', ')}`)
-  }
+  const errors = validateArchitecture(nodes)
 
   if (errors.length > 0) {
     console.error('❌ 架构检查失败')
     for (const error of errors) {
       console.error(`- ${error}`)
     }
-    process.exitCode = 1
-    return
+    return 1
   }
 
   console.info('✅ 架构检查通过')
   console.info(`- Workspace 包数量: ${nodes.length}`)
-  console.info(`- 检查项: 循环依赖、层级依赖、data 基础层约束`)
+  console.info('- 检查项: 循环依赖、层级依赖、data 基础层约束')
+  return 0
 }
 
-await main()
+const currentFilePath = fileURLToPath(import.meta.url)
+const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(currentFilePath)
+if (isDirectRun) {
+  const exitCode = await runArchitectureCheck()
+  process.exitCode = exitCode
+}

--- a/scripts/check-architecture.ts
+++ b/scripts/check-architecture.ts
@@ -1,0 +1,157 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const rootDir = process.cwd()
+const workspaceDirs = ['apps', 'packages']
+
+type WorkspaceType = 'app' | 'package'
+
+type WorkspaceNode = {
+  name: string
+  dir: string
+  type: WorkspaceType
+  deps: string[]
+}
+
+const readJson = async <T>(filePath: string): Promise<T> => {
+  const content = await readFile(filePath, 'utf8')
+  return JSON.parse(content) as T
+}
+
+const getWorkspaceNodes = async (): Promise<WorkspaceNode[]> => {
+  const nodes: WorkspaceNode[] = []
+
+  for (const workspaceDir of workspaceDirs) {
+    const absWorkspaceDir = path.join(rootDir, workspaceDir)
+    const entries = await readdir(absWorkspaceDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      const packageJsonPath = path.join(absWorkspaceDir, entry.name, 'package.json')
+
+      try {
+        const packageJson = await readJson<{
+          name: string
+          dependencies?: Record<string, string>
+          devDependencies?: Record<string, string>
+          peerDependencies?: Record<string, string>
+        }>(packageJsonPath)
+
+        const allDeps = {
+          ...packageJson.dependencies,
+          ...packageJson.devDependencies,
+          ...packageJson.peerDependencies,
+        }
+
+        const type: WorkspaceType = workspaceDir === 'apps' ? 'app' : 'package'
+
+        nodes.push({
+          name: packageJson.name,
+          dir: `${workspaceDir}/${entry.name}`,
+          type,
+          deps: Object.keys(allDeps ?? {}),
+        })
+      } catch {
+        // Ignore directories without package.json
+      }
+    }
+  }
+
+  return nodes
+}
+
+const detectCycles = (graph: Map<string, string[]>): string[][] => {
+  const cycles: string[][] = []
+  const visited = new Set<string>()
+  const inStack = new Set<string>()
+  const stack: string[] = []
+
+  const dfs = (node: string): void => {
+    visited.add(node)
+    inStack.add(node)
+    stack.push(node)
+
+    for (const next of graph.get(node) ?? []) {
+      if (!visited.has(next)) {
+        dfs(next)
+        continue
+      }
+
+      if (inStack.has(next)) {
+        const cycleStart = stack.lastIndexOf(next)
+        if (cycleStart !== -1) {
+          const cycle = [...stack.slice(cycleStart), next]
+          const signature = cycle.join(' -> ')
+          const exists = cycles.some((item) => item.join(' -> ') === signature)
+          if (!exists) {
+            cycles.push(cycle)
+          }
+        }
+      }
+    }
+
+    stack.pop()
+    inStack.delete(node)
+  }
+
+  for (const node of graph.keys()) {
+    if (!visited.has(node)) dfs(node)
+  }
+
+  return cycles
+}
+
+const main = async (): Promise<void> => {
+  const nodes = await getWorkspaceNodes()
+  const workspaceNames = new Set(nodes.map((n) => n.name))
+
+  const graph = new Map<string, string[]>()
+  for (const node of nodes) {
+    graph.set(
+      node.name,
+      node.deps.filter((dep) => workspaceNames.has(dep)),
+    )
+  }
+
+  const errors: string[] = []
+
+  const cycles = detectCycles(graph)
+  for (const cycle of cycles) {
+    errors.push(`发现循环依赖: ${cycle.join(' -> ')}`)
+  }
+
+  const nodeMap = new Map(nodes.map((node) => [node.name, node]))
+
+  for (const node of nodes) {
+    for (const dep of graph.get(node.name) ?? []) {
+      const target = nodeMap.get(dep)
+      if (!target) continue
+
+      if (node.type === 'package' && target.type === 'app') {
+        errors.push(`非法依赖: 包 ${node.name} 不能依赖应用 ${target.name}`)
+      }
+    }
+  }
+
+  const dataPackage = '@afilmory/data'
+  const dataDeps = graph.get(dataPackage) ?? []
+  if (dataDeps.length > 0) {
+    errors.push(`分层约束: ${dataPackage} 应处于基础层，不能依赖其他 workspace 包: ${dataDeps.join(', ')}`)
+  }
+
+  if (errors.length > 0) {
+    console.error('❌ 架构检查失败')
+    for (const error of errors) {
+      console.error(`- ${error}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  console.info('✅ 架构检查通过')
+  console.info(`- Workspace 包数量: ${nodes.length}`)
+  console.info(`- 检查项: 循环依赖、层级依赖、data 基础层约束`)
+}
+
+await main()

--- a/tests/unit/check-architecture-lib.test.ts
+++ b/tests/unit/check-architecture-lib.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { WorkspaceNode } from '../../scripts/check-architecture-lib'
+import { buildWorkspaceGraph, detectCycles, validateArchitecture } from '../../scripts/check-architecture-lib'
+
+const buildNodes = (): WorkspaceNode[] => [
+  { name: '@afilmory/data', dir: 'packages/data', type: 'package', deps: [] },
+  { name: '@afilmory/utils', dir: 'packages/utils', type: 'package', deps: ['@afilmory/data'] },
+  { name: '@afilmory/web', dir: 'apps/web', type: 'app', deps: ['@afilmory/utils'] },
+]
+
+test('buildWorkspaceGraph 仅保留 workspace 内依赖', () => {
+  const nodes: WorkspaceNode[] = [
+    { name: '@afilmory/data', dir: 'packages/data', type: 'package', deps: ['zod'] },
+    { name: '@afilmory/web', dir: 'apps/web', type: 'app', deps: ['@afilmory/data', 'react'] },
+  ]
+
+  const graph = buildWorkspaceGraph(nodes)
+  assert.deepEqual(graph.get('@afilmory/data'), [])
+  assert.deepEqual(graph.get('@afilmory/web'), ['@afilmory/data'])
+})
+
+test('detectCycles 能识别循环依赖', () => {
+  const graph = new Map<string, string[]>([
+    ['a', ['b']],
+    ['b', ['c']],
+    ['c', ['a']],
+  ])
+
+  const cycles = detectCycles(graph)
+  assert.equal(cycles.length, 1)
+  assert.deepEqual(cycles[0], ['a', 'b', 'c', 'a'])
+})
+
+test('validateArchitecture 对合法分层返回空错误', () => {
+  const errors = validateArchitecture(buildNodes())
+  assert.deepEqual(errors, [])
+})
+
+test('validateArchitecture 检测 package -> app 非法依赖', () => {
+  const nodes = buildNodes()
+  nodes[1].deps = ['@afilmory/web']
+
+  const errors = validateArchitecture(nodes)
+  assert.ok(errors.some((line) => line.includes('不能依赖应用 @afilmory/web')))
+})
+
+test('validateArchitecture 检测 data 基础层漂移', () => {
+  const nodes = buildNodes()
+  nodes[0].deps = ['@afilmory/utils']
+
+  const errors = validateArchitecture(nodes)
+  assert.ok(errors.some((line) => line.includes('@afilmory/data 应处于基础层')))
+})

--- a/tests/unit/manifest-queries.test.ts
+++ b/tests/unit/manifest-queries.test.ts
@@ -37,6 +37,14 @@ test('createPhotoMap maps by id and skips invalid ids', () => {
   assert.equal(map.a?.id, 'a')
 })
 
+test('createPhotoMap handles special object keys safely', () => {
+  const photo = buildPhoto('__proto__', ['x'])
+  const map = createPhotoMap([photo])
+
+  assert.equal(map['__proto__']?.id, '__proto__')
+  assert.equal(Object.getPrototypeOf(map), null)
+})
+
 test('collectSortedTags returns unique sorted tags', () => {
   const tags = collectSortedTags([buildPhoto('a', ['b', 'a']), buildPhoto('b', ['a', 'c'])])
   assert.deepEqual(tags, ['a', 'b', 'c'])

--- a/tests/unit/manifest-queries.test.ts
+++ b/tests/unit/manifest-queries.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { collectSortedTags, createPhotoMap } from '../../packages/data/src/manifest-queries'
+import type { PhotoManifestItem } from '../../packages/data/src/types'
+
+const buildPhoto = (id: string, tags: string[]): PhotoManifestItem => ({
+  id,
+  title: id,
+  dateTaken: new Date('2024-01-01').toISOString(),
+  tags,
+  description: '',
+  originalUrl: `/originals/${id}.jpg`,
+  thumbnailUrl: `/thumbnails/${id}.jpg`,
+  thumbHash: null,
+  width: 100,
+  height: 100,
+  aspectRatio: 1,
+  s3Key: `${id}.jpg`,
+  lastModified: new Date('2024-01-01').toISOString(),
+  size: 1,
+  exif: null,
+  toneAnalysis: null,
+  location: null,
+})
+
+test('createPhotoMap maps by id and skips invalid ids', () => {
+  const map = createPhotoMap([
+    buildPhoto('a', []),
+    {
+      ...buildPhoto('ignored', []),
+      id: '' as string,
+    },
+  ])
+
+  assert.deepEqual(Object.keys(map), ['a'])
+  assert.equal(map.a?.id, 'a')
+})
+
+test('collectSortedTags returns unique sorted tags', () => {
+  const tags = collectSortedTags([buildPhoto('a', ['b', 'a']), buildPhoto('b', ['a', 'c'])])
+  assert.deepEqual(tags, ['a', 'b', 'c'])
+})

--- a/tests/unit/photo-loader.test.ts
+++ b/tests/unit/photo-loader.test.ts
@@ -29,7 +29,6 @@ const manifest: AfilmoryManifest = {
   data: [buildPhoto('1', ['a', 'b']), buildPhoto('2', ['b', 'c'])],
   cameras: [
     {
-      id: 'cam-1',
       make: 'Canon',
       model: 'R6',
       displayName: 'Canon R6',
@@ -37,7 +36,6 @@ const manifest: AfilmoryManifest = {
   ],
   lenses: [
     {
-      id: 'lens-1',
       make: 'Canon',
       model: 'RF24-70',
       displayName: 'Canon RF24-70',
@@ -46,13 +44,19 @@ const manifest: AfilmoryManifest = {
 }
 
 test('PhotoLoader 基本查询能力正确', () => {
-  const loader = createPhotoLoader(manifest)
+  const logs: string[] = []
+  const logger = {
+    info: (line: string) => logs.push(line),
+    error: (line: string) => logs.push(line),
+  }
+  const loader = createPhotoLoader(manifest, logger)
 
   assert.equal(loader.getPhotos().length, 2)
   assert.equal(loader.getPhoto('1')?.id, '1')
   assert.deepEqual(loader.getAllTags(), ['a', 'b', 'c'])
   assert.equal(loader.getAllCameras().length, 1)
   assert.equal(loader.getAllLenses().length, 1)
+  assert.ok(logs.some((line) => line.includes('Loaded 2 photos')))
 })
 
 test('createRuntimePhotoLoader 显式传入 null 时不回退 runtime manifest', () => {

--- a/tests/unit/photo-loader.test.ts
+++ b/tests/unit/photo-loader.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createPhotoLoader, createRuntimePhotoLoader } from '../../packages/data/src/index'
+import type { AfilmoryManifest, PhotoManifestItem } from '../../packages/data/src/types'
+
+const buildPhoto = (id: string, tags: string[]): PhotoManifestItem => ({
+  id,
+  title: id,
+  dateTaken: new Date('2024-01-01').toISOString(),
+  tags,
+  description: '',
+  originalUrl: `/originals/${id}.jpg`,
+  thumbnailUrl: `/thumbnails/${id}.jpg`,
+  thumbHash: null,
+  width: 100,
+  height: 100,
+  aspectRatio: 1,
+  s3Key: `${id}.jpg`,
+  lastModified: new Date('2024-01-01').toISOString(),
+  size: 1,
+  exif: null,
+  toneAnalysis: null,
+  location: null,
+})
+
+const manifest: AfilmoryManifest = {
+  version: 'v7',
+  data: [buildPhoto('1', ['a', 'b']), buildPhoto('2', ['b', 'c'])],
+  cameras: [
+    {
+      id: 'cam-1',
+      make: 'Canon',
+      model: 'R6',
+      displayName: 'Canon R6',
+    },
+  ],
+  lenses: [
+    {
+      id: 'lens-1',
+      make: 'Canon',
+      model: 'RF24-70',
+      displayName: 'Canon RF24-70',
+    },
+  ],
+}
+
+test('PhotoLoader 基本查询能力正确', () => {
+  const loader = createPhotoLoader(manifest)
+
+  assert.equal(loader.getPhotos().length, 2)
+  assert.equal(loader.getPhoto('1')?.id, '1')
+  assert.deepEqual(loader.getAllTags(), ['a', 'b', 'c'])
+  assert.equal(loader.getAllCameras().length, 1)
+  assert.equal(loader.getAllLenses().length, 1)
+})
+
+test('createRuntimePhotoLoader 显式传入 null 时不回退 runtime manifest', () => {
+  const runtimeGlobal = globalThis as typeof globalThis & { __MANIFEST__?: AfilmoryManifest }
+  const originManifest = runtimeGlobal.__MANIFEST__
+  runtimeGlobal.__MANIFEST__ = manifest
+
+  try {
+    const loader = createRuntimePhotoLoader(null)
+    assert.equal(loader.getPhotos().length, 0)
+  } finally {
+    runtimeGlobal.__MANIFEST__ = originManifest
+  }
+})
+
+test('createRuntimePhotoLoader 未传参时读取 runtime manifest', () => {
+  const runtimeGlobal = globalThis as typeof globalThis & { __MANIFEST__?: AfilmoryManifest }
+  const originManifest = runtimeGlobal.__MANIFEST__
+  runtimeGlobal.__MANIFEST__ = manifest
+
+  try {
+    const loader = createRuntimePhotoLoader()
+    assert.equal(loader.getPhotos().length, 2)
+  } finally {
+    runtimeGlobal.__MANIFEST__ = originManifest
+  }
+})

--- a/tests/unit/runtime-manifest.test.ts
+++ b/tests/unit/runtime-manifest.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { resolveRuntimeManifest } from '../../packages/data/src/runtime-manifest'
+import type { RuntimeManifestGlobal } from '../../packages/data/src/runtime-manifest'
+import { resolveRuntimeManifest, resolveRuntimeManifestFrom } from '../../packages/data/src/runtime-manifest'
 import type { AfilmoryManifest } from '../../packages/data/src/types'
 
 const fixtureManifest = {
@@ -11,62 +12,41 @@ const fixtureManifest = {
   lenses: [],
 } satisfies AfilmoryManifest
 
-test('resolveRuntimeManifest 优先读取 window.__MANIFEST__', () => {
-  const runtimeGlobal = globalThis as typeof globalThis & {
-    __MANIFEST__?: AfilmoryManifest
-    window?: { __MANIFEST__?: AfilmoryManifest }
-  }
+test('resolveRuntimeManifestFrom 优先读取 window.__MANIFEST__', () => {
+  const runtimeGlobal = {
+    __MANIFEST__: null,
+    window: { __MANIFEST__: fixtureManifest },
+  } as RuntimeManifestGlobal
 
-  const originWindow = runtimeGlobal.window
-  const originManifest = runtimeGlobal.__MANIFEST__
-
-  runtimeGlobal.window = { __MANIFEST__: fixtureManifest }
-  runtimeGlobal.__MANIFEST__ = null as unknown as AfilmoryManifest
-
-  try {
-    assert.equal(resolveRuntimeManifest(), fixtureManifest)
-  } finally {
-    runtimeGlobal.window = originWindow
-    runtimeGlobal.__MANIFEST__ = originManifest
-  }
+  assert.equal(resolveRuntimeManifestFrom(runtimeGlobal), fixtureManifest)
 })
 
-test('resolveRuntimeManifest 在无 window 时读取 globalThis.__MANIFEST__', () => {
-  const runtimeGlobal = globalThis as typeof globalThis & {
-    __MANIFEST__?: AfilmoryManifest
-    window?: { __MANIFEST__?: AfilmoryManifest }
-  }
+test('resolveRuntimeManifestFrom 在无 window 时读取 globalThis.__MANIFEST__', () => {
+  const runtimeGlobal = {
+    __MANIFEST__: fixtureManifest,
+    window: undefined,
+  } as RuntimeManifestGlobal
 
-  const originWindow = runtimeGlobal.window
+  assert.equal(resolveRuntimeManifestFrom(runtimeGlobal), fixtureManifest)
+})
+
+test('resolveRuntimeManifestFrom 在缺失时返回 null', () => {
+  const runtimeGlobal = {
+    __MANIFEST__: undefined,
+    window: undefined,
+  } as RuntimeManifestGlobal
+
+  assert.equal(resolveRuntimeManifestFrom(runtimeGlobal), null)
+})
+
+test('resolveRuntimeManifest 能从 globalThis 读取', () => {
+  const runtimeGlobal = globalThis as RuntimeManifestGlobal
   const originManifest = runtimeGlobal.__MANIFEST__
 
-  runtimeGlobal.window = undefined
   runtimeGlobal.__MANIFEST__ = fixtureManifest
-
   try {
     assert.equal(resolveRuntimeManifest(), fixtureManifest)
   } finally {
-    runtimeGlobal.window = originWindow
-    runtimeGlobal.__MANIFEST__ = originManifest
-  }
-})
-
-test('resolveRuntimeManifest 在缺失时返回 null', () => {
-  const runtimeGlobal = globalThis as typeof globalThis & {
-    __MANIFEST__?: AfilmoryManifest
-    window?: { __MANIFEST__?: AfilmoryManifest }
-  }
-
-  const originWindow = runtimeGlobal.window
-  const originManifest = runtimeGlobal.__MANIFEST__
-
-  runtimeGlobal.window = undefined
-  runtimeGlobal.__MANIFEST__ = undefined
-
-  try {
-    assert.equal(resolveRuntimeManifest(), null)
-  } finally {
-    runtimeGlobal.window = originWindow
     runtimeGlobal.__MANIFEST__ = originManifest
   }
 })

--- a/tests/unit/runtime-manifest.test.ts
+++ b/tests/unit/runtime-manifest.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveRuntimeManifest } from '../../packages/data/src/runtime-manifest'
+import type { AfilmoryManifest } from '../../packages/data/src/types'
+
+const fixtureManifest = {
+  version: 'v7',
+  data: [],
+  cameras: [],
+  lenses: [],
+} satisfies AfilmoryManifest
+
+test('resolveRuntimeManifest 优先读取 window.__MANIFEST__', () => {
+  const runtimeGlobal = globalThis as typeof globalThis & {
+    __MANIFEST__?: AfilmoryManifest
+    window?: { __MANIFEST__?: AfilmoryManifest }
+  }
+
+  const originWindow = runtimeGlobal.window
+  const originManifest = runtimeGlobal.__MANIFEST__
+
+  runtimeGlobal.window = { __MANIFEST__: fixtureManifest }
+  runtimeGlobal.__MANIFEST__ = null as unknown as AfilmoryManifest
+
+  try {
+    assert.equal(resolveRuntimeManifest(), fixtureManifest)
+  } finally {
+    runtimeGlobal.window = originWindow
+    runtimeGlobal.__MANIFEST__ = originManifest
+  }
+})
+
+test('resolveRuntimeManifest 在无 window 时读取 globalThis.__MANIFEST__', () => {
+  const runtimeGlobal = globalThis as typeof globalThis & {
+    __MANIFEST__?: AfilmoryManifest
+    window?: { __MANIFEST__?: AfilmoryManifest }
+  }
+
+  const originWindow = runtimeGlobal.window
+  const originManifest = runtimeGlobal.__MANIFEST__
+
+  runtimeGlobal.window = undefined
+  runtimeGlobal.__MANIFEST__ = fixtureManifest
+
+  try {
+    assert.equal(resolveRuntimeManifest(), fixtureManifest)
+  } finally {
+    runtimeGlobal.window = originWindow
+    runtimeGlobal.__MANIFEST__ = originManifest
+  }
+})
+
+test('resolveRuntimeManifest 在缺失时返回 null', () => {
+  const runtimeGlobal = globalThis as typeof globalThis & {
+    __MANIFEST__?: AfilmoryManifest
+    window?: { __MANIFEST__?: AfilmoryManifest }
+  }
+
+  const originWindow = runtimeGlobal.window
+  const originManifest = runtimeGlobal.__MANIFEST__
+
+  runtimeGlobal.window = undefined
+  runtimeGlobal.__MANIFEST__ = undefined
+
+  try {
+    assert.equal(resolveRuntimeManifest(), null)
+  } finally {
+    runtimeGlobal.window = originWindow
+    runtimeGlobal.__MANIFEST__ = originManifest
+  }
+})


### PR DESCRIPTION
### Motivation

- 将仓库中的分层约定从文档约定升级为可执行的守卫，防止循环依赖、包反向依赖以及基础层漂移等架构回归。

### Description

- 新增可执行架构检查脚本 `scripts/check-architecture.ts`，用于扫描 `apps/*` 与 `packages/*` 的 `package.json`、构建依赖图并检测循环依赖、禁止 `package -> app` 的反向依赖、以及强制 `@afilmory/data` 作为基础层不依赖其他 workspace 包。 
- 在根 `package.json` 中添加 `check:architecture` 脚本以便通过 `pnpm check:architecture` 在本地或 CI 中运行架构检查。 
- 新增文档 `docs/architecture-review.md`，包含架构分析、发现的风险、已应用的优化以及后续建议（例如在 CI 中强制执行）。

### Testing

- 已运行 `pnpm check:architecture` 并成功返回 `✅ 架构检查通过`，确认当前 workspace 无循环依赖与违规反向依赖。 
- 在提交变更时触发了 pre-commit 检查（`prettier` + `eslint --fix`），检查并修复了风格问题后提交成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b82249bbb08320a2571fb6662f350f)