### PR TITLE
fix: restore photo viewer detail page interactions

### DIFF
--- a/apps/web/src/components/ui/photo-viewer/ExifPanel.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ExifPanel.tsx
@@ -3,13 +3,11 @@ import './PhotoViewer.css'
 import type { PhotoManifestItem, PickedExif } from '@afilmory/data'
 import { MotionButtonBase, ScrollArea, Spring } from '@afilmory/ui'
 import { isNil } from 'es-toolkit/compat'
-import { useAtomValue } from 'jotai'
 import { m } from 'motion/react'
 import type { FC } from 'react'
 import { Fragment, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { isExiftoolLoadedAtom } from '~/atoms/app'
 import { useMobile } from '~/hooks/useMobile'
 import {
   CarbonIsoOutline,
@@ -36,7 +34,6 @@ export const ExifPanel: FC<{
   const { t } = useTranslation()
   const isMobile = useMobile()
   const formattedExifData = formatExifData(exifData)
-  const isExiftoolLoaded = useAtomValue(isExiftoolLoadedAtom)
 
   // Compute decimal GPS coordinates from raw EXIF data
   const gpsData = useMemo(() => convertExifGPSToDecimal(exifData), [exifData])
@@ -86,7 +83,7 @@ export const ExifPanel: FC<{
       />
       <div className="relative z-10 mb-4 flex shrink-0 items-center justify-between p-4 pb-0">
         <h3 className={`${isMobile ? 'text-base' : 'text-lg'} font-semibold`}>{t('exif.header.title')}</h3>
-        {!isMobile && isExiftoolLoaded && <RawExifViewer currentPhoto={currentPhoto} />}
+        {!isMobile && <RawExifViewer currentPhoto={currentPhoto} />}
         {isMobile && onClose && (
           <button
             type="button"

--- a/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
@@ -1,7 +1,7 @@
 import { clsxm } from '@afilmory/ui'
 import { WebGLImageViewer } from '@afilmory/webgl-viewer'
 import { AnimatePresence, m } from 'motion/react'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
 import { useMediaQuery } from 'usehooks-ts'
@@ -95,6 +95,7 @@ export const ProgressiveImage = ({
   const { handleLongPressStart, handleLongPressEnd } = useLivePhotoControls(hasVideo, isLivePhotoPlaying, livePhotoRef)
 
   const handleWebGLLoadingStateChange = useWebGLLoadingState(loadingIndicatorRef)
+  const markHighResImageRendered = setState.setIsHighResImageRendered
 
   const handleThumbnailLoad = useCallback(() => {
     setState.setIsThumbnailLoaded(true)
@@ -105,6 +106,16 @@ export const ProgressiveImage = ({
   const isHDRSupported = useMediaQuery('(dynamic-range: high)')
   // Only use HDR if the browser supports it and the image is HDR
   const shouldUseHDR = isHDR && isHDRSupported
+  const shouldUseDOMViewer = hasVideo || shouldUseHDR || !blobSrc || !blobSrc.startsWith('blob:')
+  const shouldUseWebGLViewer = !shouldUseDOMViewer && canUseWebGL
+
+  useEffect(() => {
+    // WebGL viewer does not emit an image onLoad event like the DOM viewer path,
+    // so mark the high-res layer as rendered once the canvas-backed viewer is active.
+    if (highResLoaded && blobSrc && isActiveImage && !error && shouldUseWebGLViewer) {
+      markHighResImageRendered(true)
+    }
+  }, [blobSrc, error, highResLoaded, isActiveImage, markHighResImageRendered, shouldUseWebGLViewer])
 
   return (
     <div
@@ -123,7 +134,7 @@ export const ProgressiveImage = ({
           key={thumbnailSrc}
           alt={alt}
           className={clsxm(
-            'absolute inset-0 h-full w-full object-contain transition-opacity duration-300',
+            'pointer-events-none absolute inset-0 h-full w-full object-contain transition-opacity duration-300',
             isThumbnailLoaded ? 'opacity-100' : 'opacity-0',
           )}
           onLoad={handleThumbnailLoad}
@@ -140,7 +151,7 @@ export const ProgressiveImage = ({
           }}
         >
           {/* LivePhoto/Motion Photo 或 HDR 模式使用 DOMImageViewer */}
-          {hasVideo || shouldUseHDR ? (
+          {shouldUseDOMViewer ? (
             <DOMImageViewer
               ref={domImageViewerRef}
               onZoomChange={onDOMTransformed}

--- a/apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx
+++ b/apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx
@@ -42,6 +42,31 @@ interface RawExifViewerProps {
 
 type ParsedExifData = Record<string, string | number | boolean | null>
 
+const stringifyExifValue = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+const serializeManifestExifData = (exifData: PhotoManifest['exif']): string | null => {
+  if (!exifData) return null
+
+  const lines = Object.entries(exifData)
+    .flatMap(([key, value]) => {
+      const serialized = stringifyExifValue(value)
+      return serialized ? [`${key}: ${serialized}`] : []
+    })
+    .sort((a, b) => a.localeCompare(b))
+
+  return lines.length > 0 ? lines.join('\n') : null
+}
+
 const parseRawExifData = (rawData: string): ParsedExifData => {
   const lines = rawData.split('\n').filter((line) => line.trim())
   const data: ParsedExifData = {}
@@ -82,6 +107,9 @@ export const RawExifViewer: React.FC<RawExifViewerProps> = ({ currentPhoto }) =>
     setIsLoading(true)
     try {
       const response = await fetch(currentPhoto.originalUrl)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch original image: ${response.status}`)
+      }
       const blob = await response.blob()
       const data = await ExifToolManager.parse(blob, currentPhoto.s3Key)
 
@@ -89,11 +117,18 @@ export const RawExifViewer: React.FC<RawExifViewerProps> = ({ currentPhoto }) =>
       setIsOpen(true)
     } catch (error) {
       console.error('Failed to parse EXIF data:', error)
-      toast.error(
-        t('exif.raw.parse.error', {
-          defaultValue: 'Failed to parse EXIF data',
-        }),
-      )
+      const fallbackData = serializeManifestExifData(currentPhoto.exif)
+
+      if (fallbackData) {
+        setRawExifData(fallbackData)
+        setIsOpen(true)
+      } else {
+        toast.error(
+          t('exif.raw.parse.error', {
+            defaultValue: 'Failed to parse EXIF data',
+          }),
+        )
+      }
     } finally {
       setIsLoading(false)
     }

--- a/apps/web/src/components/ui/photo-viewer/hooks.ts
+++ b/apps/web/src/components/ui/photo-viewer/hooks.ts
@@ -94,6 +94,14 @@ export const useImageLoader = (
       loadingIndicatorRef?.current?.resetLoadingState()
     }
 
+    const isCrossOriginSource = (() => {
+      try {
+        return new URL(src, window.location.href).origin !== window.location.origin
+      } catch {
+        return false
+      }
+    })()
+
     const loadImage = async () => {
       try {
         const result = await imageLoaderManager.loadImage(src, {
@@ -108,6 +116,16 @@ export const useImageLoader = (
         onBlobSrcChange?.(result.blobSrc)
         setHighResLoaded?.(true)
       } catch (loadError) {
+        if (isCrossOriginSource) {
+          setBlobSrc?.(src)
+          onBlobSrcChange?.(src)
+          setHighResLoaded?.(true)
+          loadingIndicatorRef?.current?.updateLoadingState({
+            isVisible: false,
+          })
+          return
+        }
+
         console.error('Failed to load image:', loadError)
         setError?.(true)
 


### PR DESCRIPTION
## Summary
- restore zoom interactions on the photo detail page by preventing the thumbnail layer from blocking gestures
- fall back to direct image rendering when cross-origin blob loading fails so the original image can still load sharply
- make Raw EXIF resilient by always showing the entry and falling back to manifest EXIF data when fetching/parsing the original file fails

## Validation
- pnpm --filter @afilmory/web type-check
- pnpm exec eslint apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx apps/web/src/components/ui/photo-viewer/hooks.ts apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx apps/web/src/components/ui/photo-viewer/ExifPanel.tsx
- pnpm --filter @afilmory/web build
- browser automation against local preview confirmed the detail page renders the original image URL and mounts the DOM zoom container