### PR TITLE
fix: render cross-origin detail images with DOM viewer

### DIFF
--- a/apps/web/src/components/ui/photo-viewer/hooks.ts
+++ b/apps/web/src/components/ui/photo-viewer/hooks.ts
@@ -7,11 +7,14 @@ import { toast } from 'sonner'
 import { MenuItemSeparator, MenuItemText } from '~/atoms/context-menu'
 import { isMobileDevice } from '~/lib/device-viewport'
 import { ImageLoaderManager } from '~/lib/image-loader-manager'
+import { getImageFormat } from '~/lib/image-utils'
 
 import type { LivePhotoVideoHandle } from './LivePhotoVideo'
 import type { LoadingIndicatorRef } from './LoadingIndicator'
 import type { ProgressiveImageState } from './types'
 import { SHOW_SCALE_INDICATOR_DURATION } from './types'
+
+const DIRECT_RENDERABLE_IMAGE_FORMATS = new Set(['JPG', 'JPEG', 'PNG', 'WEBP', 'GIF', 'BMP', 'SVG', 'AVIF'])
 
 export const useProgressiveImageState = (): [
   ProgressiveImageState,
@@ -106,6 +109,20 @@ export const useImageLoader = (
         return false
       }
     })()
+    const shouldUseDirectCrossOriginImage =
+      isCrossOriginSource && DIRECT_RENDERABLE_IMAGE_FORMATS.has(getImageFormat(src))
+
+    if (shouldUseDirectCrossOriginImage) {
+      setBlobSrc?.(src)
+      onBlobSrcChange?.(src)
+      setHighResLoaded?.(true)
+      loadingIndicatorRef?.current?.updateLoadingState({
+        isVisible: false,
+      })
+      return () => {
+        imageLoaderManager.cleanup()
+      }
+    }
 
     const loadImage = async () => {
       try {


### PR DESCRIPTION
## Root Cause
When `img.misfork.com` started returning CORS-enabled responses, the detail page stopped taking the old fetch-failure fallback and began going through the blob + WebGL path again. In production that path mounts a canvas but renders no image, leaving the detail page effectively blank after the high-resolution image loads.

## Summary
- short-circuit cross-origin images that browsers can already render natively to the direct URL path
- force those images onto the DOM viewer path instead of the blob/WebGL path
- preserve zoom interactions while avoiding the blank WebGL canvas regression on production detail pages

## Validation
- pnpm --filter @afilmory/web type-check
- pnpm exec eslint apps/web/src/components/ui/photo-viewer/hooks.ts
- pnpm --filter @afilmory/web build
- browser automation on production reproduced the blank canvas state
- browser automation on local preview confirmed the detail page renders `https://img.misfork.com/afilmory/A7C09317.jpg` and mounts the DOM zoom container