### PR TITLE
fix: restore detail image loading indicator

### DIFF
--- a/apps/web/src/components/ui/photo-viewer/DOMImageViewer.tsx
+++ b/apps/web/src/components/ui/photo-viewer/DOMImageViewer.tsx
@@ -13,7 +13,7 @@ export const DOMImageViewer: FC<DOMImageViewerProps> = ({
   maxZoom,
   src,
   alt,
-  highResLoaded,
+  isVisible,
   onLoad,
   onError,
   children,
@@ -124,10 +124,7 @@ export const DOMImageViewer: FC<DOMImageViewerProps> = ({
           <img
             src={src || undefined}
             alt={alt}
-            className={clsxm(
-              'absolute inset-0 w-full h-full object-contain',
-              highResLoaded ? 'opacity-100' : 'opacity-0',
-            )}
+            className={clsxm('absolute inset-0 w-full h-full object-contain', isVisible ? 'opacity-100' : 'opacity-0')}
             draggable={false}
             loading="eager"
             decoding="async"

--- a/apps/web/src/components/ui/photo-viewer/DOMImageViewer.tsx
+++ b/apps/web/src/components/ui/photo-viewer/DOMImageViewer.tsx
@@ -15,6 +15,7 @@ export const DOMImageViewer: FC<DOMImageViewerProps> = ({
   alt,
   highResLoaded,
   onLoad,
+  onError,
   children,
 }) => {
   const transformRef = useRef<ReactZoomPanPinchRef>(null)
@@ -131,6 +132,7 @@ export const DOMImageViewer: FC<DOMImageViewerProps> = ({
             loading="eager"
             decoding="async"
             onLoad={onLoad}
+            onError={onError}
           />
           {children}
         </TransformComponent>

--- a/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
@@ -101,6 +101,22 @@ export const ProgressiveImage = ({
     setState.setIsThumbnailLoaded(true)
   }, [setState])
 
+  const handleHighResImageLoad = useCallback(() => {
+    setState.setIsHighResImageRendered(true)
+    loadingIndicatorRef.current?.updateLoadingState({
+      isVisible: false,
+    })
+  }, [loadingIndicatorRef, setState])
+
+  const handleHighResImageError = useCallback(() => {
+    setState.setError(true)
+    loadingIndicatorRef.current?.updateLoadingState({
+      isVisible: true,
+      isError: true,
+      errorMessage: t('photo.error.loading'),
+    })
+  }, [loadingIndicatorRef, setState, t])
+
   const showContextMenu = useShowContextMenu()
 
   const isHDRSupported = useMediaQuery('(dynamic-range: high)')
@@ -160,7 +176,8 @@ export const ProgressiveImage = ({
               src={blobSrc}
               alt={alt}
               highResLoaded={highResLoaded}
-              onLoad={() => setState.setIsHighResImageRendered(true)}
+              onLoad={handleHighResImageLoad}
+              onError={handleHighResImageError}
             >
               {/* LivePhoto/Motion Photo 视频组件作为 children，跟随图片的变换 */}
               {hasVideo && videoSource && imageLoaderManagerRef.current && (

--- a/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
@@ -49,10 +49,9 @@ export const ProgressiveImage = ({
   // State management
   const [state, setState] = useProgressiveImageState()
   const {
-    blobSrc,
-    highResLoaded,
-    error,
-    isHighResImageRendered,
+    resolvedSrc,
+    sourceKind,
+    loadPhase,
     currentScale,
     showScaleIndicator,
     isThumbnailLoaded,
@@ -74,16 +73,13 @@ export const ProgressiveImage = ({
   const imageLoaderManagerRef = useImageLoader(
     src,
     isCurrentImage,
-    highResLoaded,
-    error,
     onProgress,
     onError,
     onBlobSrcChange,
     loadingIndicatorRef,
-    setState.setBlobSrc,
-    setState.setHighResLoaded,
-    setState.setError,
-    setState.setIsHighResImageRendered,
+    setState.setResolvedSrc,
+    setState.setSourceKind,
+    setState.setLoadPhase,
   )
 
   const { onTransformed, onDOMTransformed } = useScaleIndicator(
@@ -95,21 +91,20 @@ export const ProgressiveImage = ({
   const { handleLongPressStart, handleLongPressEnd } = useLivePhotoControls(hasVideo, isLivePhotoPlaying, livePhotoRef)
 
   const handleWebGLLoadingStateChange = useWebGLLoadingState(loadingIndicatorRef)
-  const markHighResImageRendered = setState.setIsHighResImageRendered
 
   const handleThumbnailLoad = useCallback(() => {
     setState.setIsThumbnailLoaded(true)
   }, [setState])
 
   const handleHighResImageLoad = useCallback(() => {
-    setState.setIsHighResImageRendered(true)
+    setState.setLoadPhase('painted')
     loadingIndicatorRef.current?.updateLoadingState({
       isVisible: false,
     })
   }, [loadingIndicatorRef, setState])
 
   const handleHighResImageError = useCallback(() => {
-    setState.setError(true)
+    setState.setLoadPhase('error')
     loadingIndicatorRef.current?.updateLoadingState({
       isVisible: true,
       isError: true,
@@ -122,16 +117,21 @@ export const ProgressiveImage = ({
   const isHDRSupported = useMediaQuery('(dynamic-range: high)')
   // Only use HDR if the browser supports it and the image is HDR
   const shouldUseHDR = isHDR && isHDRSupported
-  const shouldUseDOMViewer = hasVideo || shouldUseHDR || !blobSrc || !blobSrc.startsWith('blob:')
+  const shouldUseDOMViewer = hasVideo || shouldUseHDR || sourceKind !== 'blob'
   const shouldUseWebGLViewer = !shouldUseDOMViewer && canUseWebGL
+  const hasHighResSource = Boolean(resolvedSrc)
+  const isHighResPainted = loadPhase === 'painted'
+  const hasHighResError = loadPhase === 'error'
+  const shouldRenderHighResLayer = hasHighResSource && isActiveImage && !hasHighResError
 
   useEffect(() => {
-    // WebGL viewer does not emit an image onLoad event like the DOM viewer path,
-    // so mark the high-res layer as rendered once the canvas-backed viewer is active.
-    if (highResLoaded && blobSrc && isActiveImage && !error && shouldUseWebGLViewer) {
-      markHighResImageRendered(true)
+    // WebGL viewer does not emit a DOM image onLoad event, so the closest stable
+    // point we have is when the resolved blob source is ready and the viewer path
+    // has been selected.
+    if (resolvedSrc && loadPhase === 'ready' && isActiveImage && shouldUseWebGLViewer) {
+      setState.setLoadPhase('painted')
     }
-  }, [blobSrc, error, highResLoaded, isActiveImage, markHighResImageRendered, shouldUseWebGLViewer])
+  }, [resolvedSrc, loadPhase, isActiveImage, shouldUseWebGLViewer, setState])
 
   return (
     <div
@@ -143,7 +143,7 @@ export const ProgressiveImage = ({
       onTouchEnd={handleLongPressEnd}
     >
       {/* 缩略图 - 在高分辨率图片未加载或加载失败时显示 */}
-      {thumbnailSrc && (!isHighResImageRendered || error) && (
+      {thumbnailSrc && (!isHighResPainted || hasHighResError) && (
         <img
           ref={thumbnailRef}
           src={thumbnailSrc}
@@ -158,11 +158,11 @@ export const ProgressiveImage = ({
       )}
 
       {/* 高分辨率图片 - 只在成功加载且非错误状态时显示 */}
-      {highResLoaded && blobSrc && isActiveImage && !error && (
+      {shouldRenderHighResLayer && resolvedSrc && (
         <div
           className="absolute inset-0 h-full w-full"
           onContextMenu={(e) => {
-            const items = createContextMenuItems(blobSrc, alt, t)
+            const items = createContextMenuItems(resolvedSrc, alt, t)
             showContextMenu(items, e)
           }}
         >
@@ -173,9 +173,9 @@ export const ProgressiveImage = ({
               onZoomChange={onDOMTransformed}
               minZoom={minZoom}
               maxZoom={maxZoom}
-              src={blobSrc}
+              src={resolvedSrc}
               alt={alt}
-              highResLoaded={highResLoaded}
+              isVisible={loadPhase !== 'idle'}
               onLoad={handleHighResImageLoad}
               onError={handleHighResImageError}
             >
@@ -196,7 +196,7 @@ export const ProgressiveImage = ({
             /* 非 LivePhoto 模式使用 WebGLImageViewer */
             <WebGLImageViewer
               ref={webglImageViewerRef}
-              src={blobSrc}
+              src={resolvedSrc}
               className="absolute inset-0 h-full w-full"
               width={width}
               height={height}
@@ -214,7 +214,7 @@ export const ProgressiveImage = ({
         </div>
       )}
 
-      {hasVideo && highResLoaded && blobSrc && isActiveImage && !error && (
+      {hasVideo && shouldRenderHighResLayer && resolvedSrc && (
         <LivePhotoBadge
           livePhotoRef={livePhotoRef}
           isLivePhotoPlaying={isLivePhotoPlaying}
@@ -222,10 +222,10 @@ export const ProgressiveImage = ({
         />
       )}
 
-      {shouldUseHDR && highResLoaded && blobSrc && isActiveImage && !error && <HDRBadge />}
+      {shouldUseHDR && shouldRenderHighResLayer && resolvedSrc && <HDRBadge />}
 
       {/* 备用图片（当 WebGL 不可用时） - 只在非错误状态时显示 */}
-      {!canUseWebGL && highResLoaded && blobSrc && isActiveImage && !error && (
+      {!canUseWebGL && shouldUseWebGLViewer && shouldRenderHighResLayer && resolvedSrc && (
         <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-black/20">
           <i className="i-mingcute-warning-line mb-2 text-4xl" />
           <span className="text-center text-sm text-white">{t('photo.webgl.unavailable')}</span>

--- a/apps/web/src/components/ui/photo-viewer/hooks.ts
+++ b/apps/web/src/components/ui/photo-viewer/hooks.ts
@@ -11,7 +11,7 @@ import { getImageFormat } from '~/lib/image-utils'
 
 import type { LivePhotoVideoHandle } from './LivePhotoVideo'
 import type { LoadingIndicatorRef } from './LoadingIndicator'
-import type { ProgressiveImageState } from './types'
+import type { HighResSourceKind, ProgressiveImageState } from './types'
 import { SHOW_SCALE_INDICATOR_DURATION } from './types'
 
 const DIRECT_RENDERABLE_IMAGE_FORMATS = new Set(['JPG', 'JPEG', 'PNG', 'WEBP', 'GIF', 'BMP', 'SVG', 'AVIF'])
@@ -19,20 +19,18 @@ const DIRECT_RENDERABLE_IMAGE_FORMATS = new Set(['JPG', 'JPEG', 'PNG', 'WEBP', '
 export const useProgressiveImageState = (): [
   ProgressiveImageState,
   {
-    setBlobSrc: (src: string | null) => void
-    setHighResLoaded: (loaded: boolean) => void
-    setError: (error: boolean) => void
-    setIsHighResImageRendered: (rendered: boolean) => void
+    setResolvedSrc: (src: string | null) => void
+    setSourceKind: (kind: HighResSourceKind | null) => void
+    setLoadPhase: (phase: ProgressiveImageState['loadPhase']) => void
     setCurrentScale: (scale: number) => void
     setShowScaleIndicator: (show: boolean) => void
     setIsThumbnailLoaded: (loaded: boolean) => void
     setIsLivePhotoPlaying: (playing: boolean) => void
   },
 ] => {
-  const [blobSrc, setBlobSrc] = useState<string | null>(null)
-  const [highResLoaded, setHighResLoaded] = useState(false)
-  const [error, setError] = useState(false)
-  const [isHighResImageRendered, setIsHighResImageRendered] = useState(false)
+  const [resolvedSrc, setResolvedSrc] = useState<string | null>(null)
+  const [sourceKind, setSourceKind] = useState<HighResSourceKind | null>(null)
+  const [loadPhase, setLoadPhase] = useState<ProgressiveImageState['loadPhase']>('idle')
   const [currentScale, setCurrentScale] = useState(1)
   const [showScaleIndicator, setShowScaleIndicator] = useState(false)
   const [isThumbnailLoaded, setIsThumbnailLoaded] = useState(false)
@@ -40,20 +38,18 @@ export const useProgressiveImageState = (): [
 
   return [
     {
-      blobSrc,
-      highResLoaded,
-      error,
-      isHighResImageRendered,
+      resolvedSrc,
+      sourceKind,
+      loadPhase,
       currentScale,
       showScaleIndicator,
       isThumbnailLoaded,
       isLivePhotoPlaying,
     },
     {
-      setBlobSrc,
-      setHighResLoaded,
-      setError,
-      setIsHighResImageRendered,
+      setResolvedSrc,
+      setSourceKind,
+      setLoadPhase,
       setCurrentScale,
       setShowScaleIndicator,
       setIsThumbnailLoaded,
@@ -65,27 +61,23 @@ export const useProgressiveImageState = (): [
 export const useImageLoader = (
   src: string,
   isCurrentImage: boolean,
-  _highResLoaded: boolean,
-  _error: boolean,
   onProgress?: (progress: number) => void,
   onError?: () => void,
   onBlobSrcChange?: (blobSrc: string | null) => void,
   loadingIndicatorRef?: React.RefObject<LoadingIndicatorRef | null>,
-  setBlobSrc?: (src: string | null) => void,
-  setHighResLoaded?: (loaded: boolean) => void,
-  setError?: (error: boolean) => void,
-  setIsHighResImageRendered?: (rendered: boolean) => void,
+  setResolvedSrc?: (src: string | null) => void,
+  setSourceKind?: (kind: HighResSourceKind | null) => void,
+  setLoadPhase?: (phase: ProgressiveImageState['loadPhase']) => void,
 ) => {
   const { t } = useTranslation()
   const imageLoaderManagerRef = useRef<ImageLoaderManager | null>(null)
 
   useEffect(() => {
     const resetState = () => {
-      setHighResLoaded?.(false)
-      setBlobSrc?.(null)
-      setError?.(false)
+      setResolvedSrc?.(null)
+      setSourceKind?.(null)
+      setLoadPhase?.('idle')
       onBlobSrcChange?.(null)
-      setIsHighResImageRendered?.(false)
 
       // Reset loading indicator
       loadingIndicatorRef?.current?.resetLoadingState()
@@ -119,9 +111,10 @@ export const useImageLoader = (
         loadedBytes: 0,
         totalBytes: 0,
       })
-      setBlobSrc?.(src)
+      setResolvedSrc?.(src)
+      setSourceKind?.('direct')
+      setLoadPhase?.('loading')
       onBlobSrcChange?.(src)
-      setHighResLoaded?.(true)
       return () => {
         imageLoaderManager.cleanup()
       }
@@ -137,22 +130,27 @@ export const useImageLoader = (
           },
         })
 
-        setBlobSrc?.(result.blobSrc)
+        setResolvedSrc?.(result.blobSrc)
+        setSourceKind?.(result.blobSrc.startsWith('blob:') ? 'blob' : 'direct')
+        setLoadPhase?.('ready')
         onBlobSrcChange?.(result.blobSrc)
-        setHighResLoaded?.(true)
       } catch (loadError) {
         if (isCrossOriginSource) {
-          setBlobSrc?.(src)
-          onBlobSrcChange?.(src)
-          setHighResLoaded?.(true)
           loadingIndicatorRef?.current?.updateLoadingState({
-            isVisible: false,
+            isVisible: true,
+            loadingProgress: 0,
+            loadedBytes: 0,
+            totalBytes: 0,
           })
+          setResolvedSrc?.(src)
+          setSourceKind?.('direct')
+          setLoadPhase?.('loading')
+          onBlobSrcChange?.(src)
           return
         }
 
         console.error('Failed to load image:', loadError)
-        setError?.(true)
+        setLoadPhase?.('error')
 
         // 显示错误状态，而不是完全隐藏图片
         loadingIndicatorRef?.current?.updateLoadingState({
@@ -177,10 +175,9 @@ export const useImageLoader = (
     onBlobSrcChange,
     loadingIndicatorRef,
     t,
-    setBlobSrc,
-    setHighResLoaded,
-    setError,
-    setIsHighResImageRendered,
+    setResolvedSrc,
+    setSourceKind,
+    setLoadPhase,
   ])
 
   return imageLoaderManagerRef

--- a/apps/web/src/components/ui/photo-viewer/hooks.ts
+++ b/apps/web/src/components/ui/photo-viewer/hooks.ts
@@ -113,12 +113,15 @@ export const useImageLoader = (
       isCrossOriginSource && DIRECT_RENDERABLE_IMAGE_FORMATS.has(getImageFormat(src))
 
     if (shouldUseDirectCrossOriginImage) {
+      loadingIndicatorRef?.current?.updateLoadingState({
+        isVisible: true,
+        loadingProgress: 0,
+        loadedBytes: 0,
+        totalBytes: 0,
+      })
       setBlobSrc?.(src)
       onBlobSrcChange?.(src)
       setHighResLoaded?.(true)
-      loadingIndicatorRef?.current?.updateLoadingState({
-        isVisible: false,
-      })
       return () => {
         imageLoaderManager.cleanup()
       }

--- a/apps/web/src/components/ui/photo-viewer/types.ts
+++ b/apps/web/src/components/ui/photo-viewer/types.ts
@@ -49,6 +49,9 @@ export interface WebGLImageViewerRef {
   getScale: () => number
 }
 
+export type HighResSourceKind = 'blob' | 'direct'
+export type HighResLoadPhase = 'idle' | 'loading' | 'ready' | 'painted' | 'error'
+
 export interface DOMImageViewerProps {
   ref?: React.RefObject<import('react-zoom-pan-pinch').ReactZoomPanPinchRef | null>
   onZoomChange?: (isZoomed: boolean, scale: number) => any
@@ -56,7 +59,7 @@ export interface DOMImageViewerProps {
   maxZoom: number
   src: string
   alt: string
-  highResLoaded: boolean
+  isVisible: boolean
   onLoad?: () => void
   onError?: () => void
   children?: React.ReactNode
@@ -69,10 +72,9 @@ export interface LivePhotoBadgeProps {
 }
 
 export interface ProgressiveImageState {
-  blobSrc: string | null
-  highResLoaded: boolean
-  error: boolean
-  isHighResImageRendered: boolean
+  resolvedSrc: string | null
+  sourceKind: HighResSourceKind | null
+  loadPhase: HighResLoadPhase
   currentScale: number
   showScaleIndicator: boolean
   isThumbnailLoaded: boolean

--- a/apps/web/src/components/ui/photo-viewer/types.ts
+++ b/apps/web/src/components/ui/photo-viewer/types.ts
@@ -58,6 +58,7 @@ export interface DOMImageViewerProps {
   alt: string
   highResLoaded: boolean
   onLoad?: () => void
+  onError?: () => void
   children?: React.ReactNode
 }
 

--- a/apps/web/src/lib/image-utils.ts
+++ b/apps/web/src/lib/image-utils.ts
@@ -6,7 +6,8 @@
 export const getImageFormat = (url: string): string => {
   if (!url) return 'UNKNOWN'
 
-  const extension = url.split('.').pop()?.toUpperCase()
+  const sanitizedUrl = url.split('?')[0]?.split('#')[0] ?? url
+  const extension = sanitizedUrl.split('.').pop()?.toUpperCase()
   return extension || 'UNKNOWN'
 }
 


### PR DESCRIPTION
## Root Cause
The recent cross-origin direct-image fix moved detail-page loading onto the DOM image path for `img.misfork.com` originals, but the loading indicator was still wired to the old blob/WebGL loading flow. As a result, the indicator was hidden immediately instead of staying visible until the high-resolution `<img>` actually finished loading.

## Summary
- keep the loading indicator visible for direct-rendered cross-origin detail images
- hide the indicator only after the DOM image fires `onLoad`
- surface DOM image load failures through the existing detail-page error state

## Validation
- pnpm --filter @afilmory/web type-check
- pnpm exec eslint apps/web/src/components/ui/photo-viewer/hooks.ts apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx apps/web/src/components/ui/photo-viewer/DOMImageViewer.tsx apps/web/src/components/ui/photo-viewer/types.ts
- pnpm --filter @afilmory/web build