### PR TITLE
fix: stabilize photo viewer detail state

### DIFF
--- a/apps/web/src/components/ui/photo-viewer/ExifPanel.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ExifPanel.tsx
@@ -83,16 +83,19 @@ export const ExifPanel: FC<{
       />
       <div className="relative z-10 mb-4 flex shrink-0 items-center justify-between p-4 pb-0">
         <h3 className={`${isMobile ? 'text-base' : 'text-lg'} font-semibold`}>{t('exif.header.title')}</h3>
-        {!isMobile && <RawExifViewer currentPhoto={currentPhoto} />}
-        {isMobile && onClose && (
-          <button
-            type="button"
-            className="glassmorphic-btn border-accent/20 flex size-6 items-center justify-center rounded-full border text-white/70 duration-200 hover:text-white"
-            onClick={onClose}
-          >
-            <i className="i-mingcute-close-line text-sm" />
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          <RawExifViewer currentPhoto={currentPhoto} />
+          {isMobile && onClose && (
+            <button
+              type="button"
+              aria-label={t('common.close', { defaultValue: 'Close' })}
+              className="glassmorphic-btn border-accent/20 flex size-6 items-center justify-center rounded-full border text-white/70 duration-200 hover:text-white"
+              onClick={onClose}
+            >
+              <i className="i-mingcute-close-line text-sm" />
+            </button>
+          )}
+        </div>
       </div>
 
       <ScrollArea

--- a/apps/web/src/components/ui/photo-viewer/LoadingIndicator.tsx
+++ b/apps/web/src/components/ui/photo-viewer/LoadingIndicator.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useImperativeHandle, useState } from 'react'
+import { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+const MIN_VISIBLE_DURATION_MS = 300
 
 interface LoadingState {
   isVisible: boolean
@@ -48,24 +50,62 @@ const initialLoadingState: LoadingState = {
 export const LoadingIndicator = ({ ref }: { ref?: React.Ref<LoadingIndicatorRef | null> }) => {
   const { t } = useTranslation()
   const [loadingState, setLoadingState] = useState<LoadingState>(initialLoadingState)
+  const visibleSinceRef = useRef<number | null>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearHideTimer = useCallback(() => {
+    if (!hideTimerRef.current) return
+    clearTimeout(hideTimerRef.current)
+    hideTimerRef.current = null
+  }, [])
+
+  const hideImmediately = useCallback(() => {
+    clearHideTimer()
+    visibleSinceRef.current = null
+    setLoadingState(initialLoadingState)
+  }, [clearHideTimer])
+
+  useEffect(() => hideImmediately, [hideImmediately])
 
   useImperativeHandle(
     ref,
     useCallback(
       () => ({
         updateLoadingState: (partialState: Partial<LoadingState>) => {
-          setLoadingState((prev) => {
-            if (partialState.isVisible === false) {
-              return initialLoadingState
+          if (partialState.isVisible === false) {
+            const visibleSince = visibleSinceRef.current
+            if (visibleSince === null) {
+              hideImmediately()
+              return
             }
-            return { ...prev, ...partialState }
+
+            const elapsed = Date.now() - visibleSince
+            const remaining = MIN_VISIBLE_DURATION_MS - elapsed
+            if (remaining <= 0) {
+              hideImmediately()
+              return
+            }
+
+            clearHideTimer()
+            hideTimerRef.current = setTimeout(() => {
+              hideImmediately()
+            }, remaining)
+            return
+          }
+
+          clearHideTimer()
+          setLoadingState((prev) => {
+            if (!prev.isVisible) {
+              visibleSinceRef.current = Date.now()
+            }
+            return { ...prev, ...partialState, isVisible: true }
           })
         },
         resetLoadingState: () => {
-          setLoadingState(initialLoadingState)
+          hideImmediately()
         },
       }),
-      [],
+      [clearHideTimer, hideImmediately],
     ),
   )
 

--- a/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
+++ b/apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx
@@ -1,7 +1,7 @@
 import { clsxm } from '@afilmory/ui'
 import { WebGLImageViewer } from '@afilmory/webgl-viewer'
 import { AnimatePresence, m } from 'motion/react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ReactZoomPanPinchRef } from 'react-zoom-pan-pinch'
 import { useMediaQuery } from 'usehooks-ts'
@@ -124,14 +124,12 @@ export const ProgressiveImage = ({
   const hasHighResError = loadPhase === 'error'
   const shouldRenderHighResLayer = hasHighResSource && isActiveImage && !hasHighResError
 
-  useEffect(() => {
-    // WebGL viewer does not emit a DOM image onLoad event, so the closest stable
-    // point we have is when the resolved blob source is ready and the viewer path
-    // has been selected.
-    if (resolvedSrc && loadPhase === 'ready' && isActiveImage && shouldUseWebGLViewer) {
-      setState.setLoadPhase('painted')
-    }
-  }, [resolvedSrc, loadPhase, isActiveImage, shouldUseWebGLViewer, setState])
+  const handleWebGLImagePainted = useCallback(() => {
+    setState.setLoadPhase('painted')
+    loadingIndicatorRef.current?.updateLoadingState({
+      isVisible: false,
+    })
+  }, [loadingIndicatorRef, setState])
 
   return (
     <div
@@ -208,6 +206,7 @@ export const ProgressiveImage = ({
               smooth={true}
               onZoomChange={onTransformed}
               onLoadingStateChange={handleWebGLLoadingStateChange}
+              onImagePainted={handleWebGLImagePainted}
               debug={import.meta.env.DEV}
             />
           )}

--- a/apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx
+++ b/apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx
@@ -153,6 +153,8 @@ export const RawExifViewer: React.FC<RawExifViewerProps> = ({ currentPhoto }) =>
           type="button"
           onClick={handleOpenModal}
           disabled={isLoading}
+          aria-label={t('exif.raw.title', { defaultValue: 'Raw EXIF Data' })}
+          title={t('exif.raw.title', { defaultValue: 'Raw EXIF Data' })}
           className="cursor-pointer text-white/70 duration-200 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isLoading ? (

--- a/packages/webgl-viewer/src/WebGLImageViewer.tsx
+++ b/packages/webgl-viewer/src/WebGLImageViewer.tsx
@@ -43,6 +43,7 @@ export const WebGLImageViewer = ({
   onZoomChange,
   onImageCopied,
   onLoadingStateChange,
+  onImagePainted,
   debug = false,
   ...divProps
 }: WebGLImageViewerProps &
@@ -82,6 +83,7 @@ export const WebGLImageViewer = ({
       onZoomChange: onZoomChange || (() => {}),
       onImageCopied: onImageCopied || (() => {}),
       onLoadingStateChange: onLoadingStateChange || (() => {}),
+      onImagePainted: onImagePainted || (() => {}),
       debug: debug || false,
     }),
     [
@@ -104,6 +106,7 @@ export const WebGLImageViewer = ({
       onZoomChange,
       onImageCopied,
       onLoadingStateChange,
+      onImagePainted,
       debug,
     ],
   )

--- a/packages/webgl-viewer/src/WebGLImageViewerEngine.ts
+++ b/packages/webgl-viewer/src/WebGLImageViewerEngine.ts
@@ -89,6 +89,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
     state?: LoadingState,
     quality?: 'high' | 'medium' | 'low' | 'unknown',
   ) => void
+  private onImagePainted?: () => void
   private onDebugUpdate?: React.RefObject<(debugInfo: any) => void>
 
   // 当前质量状态
@@ -137,6 +138,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   // Promise resolvers for loadImage
   private loadImageResolve: (() => void) | null = null
   private loadImageReject: ((error: Error) => void) | null = null
+  private hasNotifiedImagePainted = false
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -149,6 +151,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
     this.onZoomChange = config.onZoomChange
     this.onImageCopied = config.onImageCopied
     this.onLoadingStateChange = config.onLoadingStateChange
+    this.onImagePainted = config.onImagePainted
     this.onDebugUpdate = onDebugUpdate
 
     // 初始化 WebGL
@@ -460,6 +463,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   }
 
   async loadImage(url: string, preknownWidth?: number, preknownHeight?: number) {
+    this.hasNotifiedImagePainted = false
     this.originalImageSrc = url
     this.isLoadingTexture = true
     this.notifyLoadingStateChange(true, LoadingState.IMAGE_LOADING)
@@ -474,7 +478,6 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
       this.loadImageResolve = resolve
       this.loadImageReject = reject
 
-      console.info('[Engine] Posting "load-image" to worker', this.worker)
       this.worker?.postMessage({
         type: 'load-image',
         payload: { url },
@@ -935,6 +938,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
     }
 
     this.drawTileOutlines(outlinedTileMatrices)
+    this.notifyImagePainted()
 
     // 更新调试信息
     this.updateDebugInfo()
@@ -945,6 +949,19 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
       this.lastTileUpdateTime = performance.now()
       setTimeout(() => this.updateTileCache(), 0)
     }
+  }
+
+  private notifyImagePainted() {
+    if (this.hasNotifiedImagePainted || !this.imageLoaded || !this.texture) {
+      return
+    }
+
+    if (this.canvas.width === 0 || this.canvas.height === 0) {
+      return
+    }
+
+    this.hasNotifiedImagePainted = true
+    this.onImagePainted?.()
   }
 
   private createTileMatrix(tileX: number, tileY: number, lodLevel: number): Float32Array {

--- a/packages/webgl-viewer/src/interface.ts
+++ b/packages/webgl-viewer/src/interface.ts
@@ -52,6 +52,7 @@ export interface WebGLImageViewerProps {
     state?: LoadingState,
     quality?: 'high' | 'medium' | 'low' | 'unknown',
   ) => void
+  onImagePainted?: () => void
   debug?: boolean
 }
 export interface WebGLImageViewerRef {


### PR DESCRIPTION
## Summary
- wait for a real WebGL first-paint signal before marking detail images as painted
- keep the detail loading indicator visible long enough to be perceived
- make the Raw EXIF entry available from the photo info panel on mobile too

## Verification
- pnpm --filter @afilmory/web type-check
- pnpm exec eslint apps/web/src/components/ui/photo-viewer/ProgressiveImage.tsx apps/web/src/components/ui/photo-viewer/LoadingIndicator.tsx apps/web/src/components/ui/photo-viewer/ExifPanel.tsx apps/web/src/components/ui/photo-viewer/RawExifViewer.tsx packages/webgl-viewer/src/interface.ts packages/webgl-viewer/src/WebGLImageViewer.tsx packages/webgl-viewer/src/WebGLImageViewerEngine.ts
- pnpm --filter @afilmory/web build
- git diff --check