### PR TITLE
[codex] fix photo runtime cleanup and caching

### DIFF
--- a/apps/web/plugins/vite/build-assets.ts
+++ b/apps/web/plugins/vite/build-assets.ts
@@ -64,7 +64,7 @@ export function buildAssetsPlugin(ogOptions: OGImagePluginOptions = {}, siteConf
         this.info(`OG image generated: ${ogImagePath}`)
 
         // 清理旧的 OG 图片
-        await cleanupOldOGImages(3)
+        await cleanupOldOGImages(1)
       } catch (error) {
         console.error('Failed to generate OG image:', error)
       }

--- a/apps/web/plugins/vite/photos-static.ts
+++ b/apps/web/plugins/vite/photos-static.ts
@@ -129,7 +129,7 @@ export function photosStaticPlugin(): Plugin {
         res.setHeader('Content-Type', contentType)
 
         // 设置缓存头
-        res.setHeader('Cache-Control', 'public, max-age=31536000') // 1 year
+        res.setHeader('Cache-Control', 'no-store')
         const etag = generateETag(stats)
         res.setHeader('ETag', etag)
 

--- a/apps/web/src/components/ui/photo-viewer/LivePhotoVideo.tsx
+++ b/apps/web/src/components/ui/photo-viewer/LivePhotoVideo.tsx
@@ -7,6 +7,20 @@ import type { ImageLoaderManager } from '~/lib/image-loader-manager'
 import type { LoadingIndicatorRef } from './LoadingIndicator'
 import type { VideoSource } from './types'
 
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+function resetVideoElement(videoElement: HTMLVideoElement | null): void {
+  if (!videoElement) {
+    return
+  }
+
+  videoElement.pause()
+  videoElement.removeAttribute('src')
+  videoElement.load()
+}
+
 interface LivePhotoVideoProps {
   /** Video source (Live Photo or Motion Photo) */
   videoSource: VideoSource
@@ -45,6 +59,7 @@ export const LivePhotoVideo = ({
   const [livePhotoVideoLoaded, setLivePhotoVideoLoaded] = useState(false)
   const [isConvertingVideo, setIsConvertingVideo] = useState(false)
   const hasAutoPlayedRef = useRef(false)
+  const isConvertingVideoRef = useRef(false)
 
   const videoRef = useRef<HTMLVideoElement>(null)
   const videoAnimateController = useAnimationControls()
@@ -54,7 +69,11 @@ export const LivePhotoVideo = ({
   }, [isPlayingLivePhoto, onPlayingChange])
 
   useEffect(() => {
-    if (!isCurrentImage || livePhotoVideoLoaded || isConvertingVideo || !videoRef.current) {
+    isConvertingVideoRef.current = isConvertingVideo
+  }, [isConvertingVideo])
+
+  useEffect(() => {
+    if (!isCurrentImage || livePhotoVideoLoaded || isConvertingVideoRef.current || !videoRef.current) {
       return
     }
     // 如果没有视频源，直接返回
@@ -62,35 +81,63 @@ export const LivePhotoVideo = ({
       return
     }
 
+    let cancelled = false
+    const currentVideoElement = videoRef.current
+    isConvertingVideoRef.current = true
     setIsConvertingVideo(true)
+
     const processVideo = async () => {
       try {
-        await imageLoaderManager.processVideo(videoSource, videoRef.current!, {
+        await imageLoaderManager.processVideo(videoSource, currentVideoElement, {
           onLoadingStateUpdate: (state) => {
             loadingIndicatorRef.current?.updateLoadingState(state)
           },
         })
 
-        setLivePhotoVideoLoaded(true)
+        if (!cancelled) {
+          setLivePhotoVideoLoaded(true)
+        }
       } catch (videoError) {
-        console.error('Failed to process video:', videoError)
+        if (!cancelled && !isAbortLikeError(videoError)) {
+          console.error('Failed to process video:', videoError)
+        }
       } finally {
-        setIsConvertingVideo(false)
+        if (!cancelled) {
+          isConvertingVideoRef.current = false
+          setIsConvertingVideo(false)
+        }
       }
     }
+
     processVideo()
-  }, [isCurrentImage, livePhotoVideoLoaded, isConvertingVideo, videoSource, imageLoaderManager, loadingIndicatorRef])
+
+    return () => {
+      cancelled = true
+      isConvertingVideoRef.current = false
+      resetVideoElement(currentVideoElement)
+    }
+  }, [isCurrentImage, livePhotoVideoLoaded, videoSource, imageLoaderManager, loadingIndicatorRef])
 
   useEffect(() => {
     if (!isCurrentImage) {
       setIsPlayingLivePhoto(false)
       setLivePhotoVideoLoaded(false)
+      isConvertingVideoRef.current = false
       setIsConvertingVideo(false)
       hasAutoPlayedRef.current = false
 
       videoAnimateController.set({ opacity: 0 })
+      resetVideoElement(videoRef.current)
     }
   }, [isCurrentImage, videoAnimateController])
+
+  useEffect(() => {
+    const currentVideoElement = videoRef.current
+
+    return () => {
+      resetVideoElement(currentVideoElement)
+    }
+  }, [])
 
   const play = useCallback(async () => {
     if (!livePhotoVideoLoaded || isPlayingLivePhoto || isConvertingVideo) return
@@ -103,7 +150,10 @@ export const LivePhotoVideo = ({
       const video = videoRef.current
       if (video) {
         video.currentTime = 0
-        video.play()
+        void video.play().catch((error: unknown) => {
+          console.error('Failed to play live photo video:', error)
+          setIsPlayingLivePhoto(false)
+        })
       }
     }, 0)
   }, [livePhotoVideoLoaded, isPlayingLivePhoto, isConvertingVideo, videoAnimateController])

--- a/apps/web/src/components/ui/photo-viewer/SharePanel.tsx
+++ b/apps/web/src/components/ui/photo-viewer/SharePanel.tsx
@@ -32,6 +32,10 @@ interface SocialShareOption {
   bgColor: string
 }
 
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
 export const SharePanel = ({ photo, trigger, blobSrc }: SharePanelProps) => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
@@ -76,38 +80,52 @@ export const SharePanel = ({ photo, trigger, blobSrc }: SharePanelProps) => {
     const shareUrl = window.location.href
     const shareTitle = photo.title || t('photo.share.default.title')
     const shareText = t('photo.share.text', { title: shareTitle })
+    const sharePayload = {
+      title: shareTitle,
+      text: shareText,
+      url: shareUrl,
+    }
 
     try {
-      // 优先使用 blobSrc（转换后的图片），如果没有则使用 originalUrl
-      const imageUrl = blobSrc || photo.originalUrl
-      const response = await fetch(imageUrl)
-      const blob = await response.blob()
-      const file = new File([blob], `${photo.title || 'photo'}.jpg`, {
-        type: blob.type || 'image/jpeg',
-      })
+      if (navigator.canShare) {
+        const imageUrl = blobSrc || photo.originalUrl
+        const response = await fetch(imageUrl)
+        const blob = await response.blob()
+        const file = new File([blob], `${photo.title || 'photo'}.jpg`, {
+          type: blob.type || 'image/jpeg',
+        })
 
-      // 检查是否支持文件分享
-      if (navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          title: shareTitle,
-          text: shareText,
-          url: shareUrl,
-          files: [file],
-        })
-      } else {
-        // 不支持文件分享，只分享链接
-        await navigator.share({
-          title: shareTitle,
-          text: shareText,
-          url: shareUrl,
-        })
+        if (navigator.canShare({ files: [file] })) {
+          await navigator.share({
+            ...sharePayload,
+            files: [file],
+          })
+          setIsOpen(false)
+          return
+        }
       }
+
+      await navigator.share(sharePayload)
       setIsOpen(false)
-    } catch {
-      // 如果分享失败，复制链接
-      await navigator.clipboard.writeText(shareUrl)
-      toast.success(t('photo.share.link.copied'))
-      setIsOpen(false)
+    } catch (error) {
+      if (isAbortLikeError(error)) {
+        setIsOpen(false)
+        return
+      }
+
+      if (navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(shareUrl)
+          toast.success(t('photo.share.link.copied'))
+          setIsOpen(false)
+          return
+        } catch {
+          toast.error(t('photo.share.copy.failed'))
+          return
+        }
+      }
+
+      toast.error(t('photo.share.copy.failed'))
     }
   }, [photo.title, blobSrc, photo.originalUrl, t])
 

--- a/apps/web/src/components/ui/photo-viewer/hooks.ts
+++ b/apps/web/src/components/ui/photo-viewer/hooks.ts
@@ -13,6 +13,10 @@ import type { LoadingIndicatorRef } from './LoadingIndicator'
 import type { ProgressiveImageState } from './types'
 import { SHOW_SCALE_INDICATOR_DURATION } from './types'
 
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
 export const useProgressiveImageState = (): [
   ProgressiveImageState,
   {
@@ -47,7 +51,7 @@ export const useProgressiveImageState = (): [
       setIsLivePhotoPlaying,
     }),
     // useState setters are stable across renders, so this memo never recomputes
-     
+
     [],
   )
 
@@ -101,6 +105,8 @@ export const useImageLoader = (
       loadingIndicatorRef?.current?.resetLoadingState()
     }
 
+    let cancelled = false
+
     const loadImage = async () => {
       try {
         const result = await imageLoaderManager.loadImage(src, {
@@ -111,10 +117,18 @@ export const useImageLoader = (
           },
         })
 
+        if (cancelled) {
+          return
+        }
+
         setBlobSrc?.(result.blobSrc)
         onBlobSrcChange?.(result.blobSrc)
         setHighResLoaded?.(true)
       } catch (loadError) {
+        if (cancelled || isAbortLikeError(loadError)) {
+          return
+        }
+
         console.error('Failed to load image:', loadError)
         setError?.(true)
 
@@ -131,7 +145,9 @@ export const useImageLoader = (
     loadImage()
 
     return () => {
+      cancelled = true
       imageLoaderManager.cleanup()
+      imageLoaderManagerRef.current = null
     }
   }, [
     highResLoaded,

--- a/apps/web/src/hooks/useLivePhotoHandler.ts
+++ b/apps/web/src/hooks/useLivePhotoHandler.ts
@@ -9,6 +9,20 @@ interface UseLivePhotoHandlerProps {
   imageLoaded: boolean
 }
 
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+function resetVideoElement(videoElement: HTMLVideoElement | null): void {
+  if (!videoElement) {
+    return
+  }
+
+  videoElement.pause()
+  videoElement.removeAttribute('src')
+  videoElement.load()
+}
+
 export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerProps) => {
   const { id, video, originalUrl } = data
   const [isPlayingLivePhoto, setIsPlayingLivePhoto] = useState(false)
@@ -28,12 +42,7 @@ export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerPr
     setIsConvertingVideo(false)
     setVideoConversionError(null)
 
-    const video = videoRef.current
-    if (video) {
-      video.pause()
-      video.removeAttribute('src')
-      video.load()
-    }
+    resetVideoElement(videoRef.current)
   }, [id])
 
   // Live Photo/Motion Photo video loading logic
@@ -79,7 +88,7 @@ export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerPr
           }
         }
       } catch (videoError) {
-        if (!cancelled) {
+        if (!cancelled && !isAbortLikeError(videoError)) {
           console.error('Failed to process video:', videoError)
           setVideoConversionError(videoError)
         }
@@ -98,6 +107,7 @@ export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerPr
         imageLoaderManagerRef.current.cleanup()
         imageLoaderManagerRef.current = null
       }
+      resetVideoElement(videoEl)
     }
   }, [video, originalUrl, imageLoaded, livePhotoVideoLoaded])
 
@@ -112,7 +122,10 @@ export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerPr
       const video = videoRef.current
       if (video) {
         video.currentTime = 0
-        video.play()
+        void video.play().catch((error: unknown) => {
+          console.error('Failed to play masonry live photo video:', error)
+          setIsPlayingLivePhoto(false)
+        })
       }
     }, 200)
   }, [hasVideo, livePhotoVideoLoaded, isPlayingLivePhoto, isConvertingVideo])
@@ -139,11 +152,20 @@ export const useLivePhotoHandler = ({ data, imageLoaded }: UseLivePhotoHandlerPr
 
   // Clean up timer on unmount
   useEffect(() => {
+    const currentVideoElement = videoRef.current
+
     return () => {
       if (hoverTimerRef.current) {
         clearTimeout(hoverTimerRef.current)
         hoverTimerRef.current = null
       }
+
+      if (imageLoaderManagerRef.current) {
+        imageLoaderManagerRef.current.cleanup()
+        imageLoaderManagerRef.current = null
+      }
+
+      resetVideoElement(currentVideoElement)
     }
   }, [])
 

--- a/apps/web/src/lib/image-loader-manager.ts
+++ b/apps/web/src/lib/image-loader-manager.ts
@@ -42,6 +42,12 @@ export interface ImageCacheResult {
   format: string
 }
 
+function createAbortError(message: string): Error {
+  const error = new Error(message)
+  error.name = 'AbortError'
+  return error
+}
+
 // Regular image cache using LRU cache
 const regularImageCache: LRUCache<string, ImageCacheResult> = new LRUCache<string, ImageCacheResult>(
   50, // Cache size for regular images
@@ -66,6 +72,93 @@ function generateRegularImageCacheKey(url: string): string {
 export class ImageLoaderManager {
   private currentXHR: XMLHttpRequest | null = null
   private delayTimer: NodeJS.Timeout | null = null
+  private pendingLoadReject: ((reason?: unknown) => void) | null = null
+  private pendingVideoReject: ((reason?: unknown) => void) | null = null
+  private pendingVideoCleanup: (() => void) | null = null
+  private currentVideoAbortController: AbortController | null = null
+  private activeVideoElement: HTMLVideoElement | null = null
+  private ownedVideoUrl: string | null = null
+
+  private rejectPendingVideo(error: Error): void {
+    if (this.pendingVideoReject) {
+      const rejectVideo = this.pendingVideoReject
+      this.pendingVideoReject = null
+      rejectVideo(error)
+    }
+  }
+
+  private clearVideoElement(): void {
+    this.rejectPendingVideo(createAbortError('Video load cancelled'))
+
+    if (this.pendingVideoCleanup) {
+      this.pendingVideoCleanup()
+      this.pendingVideoCleanup = null
+    }
+
+    const videoElement = this.activeVideoElement
+    if (videoElement) {
+      try {
+        videoElement.pause()
+      } catch (error) {
+        console.warn('Failed to pause video during cleanup:', error)
+      }
+
+      videoElement.removeAttribute('src')
+      videoElement.load()
+    }
+
+    if (this.ownedVideoUrl) {
+      try {
+        URL.revokeObjectURL(this.ownedVideoUrl)
+        debugLog('Revoked owned video blob URL during cleanup')
+      } catch (error) {
+        console.warn('Failed to revoke owned video blob URL:', error)
+      }
+    }
+
+    this.activeVideoElement = null
+    this.ownedVideoUrl = null
+  }
+
+  private setVideoSource(videoElement: HTMLVideoElement, src: string, options: { ownedBlobUrl?: boolean } = {}): void {
+    this.clearVideoElement()
+    this.activeVideoElement = videoElement
+    this.ownedVideoUrl = options.ownedBlobUrl ? src : null
+    videoElement.src = src
+    videoElement.load()
+  }
+
+  private waitForVideoReady(videoElement: HTMLVideoElement, result: VideoProcessResult): Promise<VideoProcessResult> {
+    return new Promise((resolve, reject) => {
+      this.pendingVideoReject = reject
+
+      const cleanup = () => {
+        videoElement.removeEventListener('canplaythrough', handleVideoCanPlay)
+        videoElement.removeEventListener('error', handleVideoError)
+        if (this.pendingVideoCleanup === cleanup) {
+          this.pendingVideoCleanup = null
+        }
+        if (this.pendingVideoReject === reject) {
+          this.pendingVideoReject = null
+        }
+      }
+
+      const handleVideoCanPlay = () => {
+        cleanup()
+        resolve(result)
+      }
+
+      const handleVideoError = () => {
+        cleanup()
+        reject(new Error('Video failed to load'))
+      }
+
+      this.pendingVideoCleanup = cleanup
+
+      videoElement.addEventListener('canplaythrough', handleVideoCanPlay)
+      videoElement.addEventListener('error', handleVideoError)
+    })
+  }
 
   /**
    * 验证 Blob 是否为有效的图片格式
@@ -112,12 +205,34 @@ export class ImageLoaderManager {
     })
 
     return new Promise((resolve, reject) => {
+      this.pendingLoadReject = reject
+
+      const resolveLoad = (result: ImageLoadResult) => {
+        if (this.pendingLoadReject === reject) {
+          this.pendingLoadReject = null
+        }
+        resolve(result)
+      }
+
+      const rejectLoad = (error: unknown) => {
+        if (this.pendingLoadReject === reject) {
+          this.pendingLoadReject = null
+        }
+        reject(error)
+      }
+
       this.delayTimer = setTimeout(async () => {
+        this.delayTimer = null
         const xhr = new XMLHttpRequest()
         xhr.open('GET', src)
         xhr.responseType = 'blob'
+        this.currentXHR = xhr
 
         xhr.onload = async () => {
+          if (this.currentXHR === xhr) {
+            this.currentXHR = null
+          }
+
           if (xhr.status === 200) {
             try {
               // 验证响应是否为图片
@@ -127,7 +242,7 @@ export class ImageLoaderManager {
                   isVisible: false,
                 })
                 onError?.()
-                reject(new Error('Response is not a valid image'))
+                rejectLoad(new Error('Response is not a valid image'))
                 return
               }
 
@@ -136,20 +251,20 @@ export class ImageLoaderManager {
                 src, // 传递原始 URL
                 callbacks,
               )
-              resolve(result)
+              resolveLoad(result)
             } catch (error) {
               onLoadingStateUpdate?.({
                 isVisible: false,
               })
               onError?.()
-              reject(error)
+              rejectLoad(error)
             }
           } else {
             onLoadingStateUpdate?.({
               isVisible: false,
             })
             onError?.()
-            reject(new Error(`HTTP ${xhr.status}`))
+            rejectLoad(new Error(`HTTP ${xhr.status}`))
           }
         }
 
@@ -168,18 +283,33 @@ export class ImageLoaderManager {
           }
         }
 
+        xhr.onabort = () => {
+          if (this.currentXHR === xhr) {
+            this.currentXHR = null
+          }
+
+          onLoadingStateUpdate?.({
+            isVisible: false,
+          })
+
+          rejectLoad(createAbortError('Image load cancelled'))
+        }
+
         xhr.onerror = () => {
+          if (this.currentXHR === xhr) {
+            this.currentXHR = null
+          }
+
           // Hide loading indicator on error
           onLoadingStateUpdate?.({
             isVisible: false,
           })
 
           onError?.()
-          reject(new Error('Network error'))
+          rejectLoad(new Error('Network error'))
         }
 
         xhr.send()
-        this.currentXHR = xhr
       }, 300)
     })
   }
@@ -193,78 +323,61 @@ export class ImageLoaderManager {
     callbacks: LoadingCallbacks = {},
   ): Promise<VideoProcessResult> {
     const { onLoadingStateUpdate } = callbacks
+    const i18n = jotaiStore.get(i18nAtom)
 
-    return new Promise((resolve, reject) => {
-      const processVideo = async () => {
-        const i18n = jotaiStore.get(i18nAtom)
+    this.currentVideoAbortController?.abort()
+    this.currentVideoAbortController = new AbortController()
 
-        try {
-          // Pattern matching on VideoSource
-          if (videoSource.type === 'motion-photo') {
-            // Motion Photo: 从图片中提取嵌入视频
-            debugLog('Processing Motion Photo embedded video...')
-            onLoadingStateUpdate?.({
-              isVisible: true,
-              conversionMessage: i18n.t('video.motion-photo.extracting'),
-            })
+    try {
+      if (videoSource.type === 'motion-photo') {
+        debugLog('Processing Motion Photo embedded video...')
+        onLoadingStateUpdate?.({
+          isVisible: true,
+          conversionMessage: i18n.t('video.motion-photo.extracting'),
+        })
 
-            const extractedVideoUrl = await extractMotionPhotoVideo(videoSource.imageUrl, {
-              motionPhotoOffset: videoSource.offset,
-              motionPhotoVideoSize: videoSource.size,
-              presentationTimestampUs: videoSource.presentationTimestamp,
-            })
+        const extractedVideoUrl = await extractMotionPhotoVideo(
+          videoSource.imageUrl,
+          {
+            motionPhotoOffset: videoSource.offset,
+            motionPhotoVideoSize: videoSource.size,
+            presentationTimestampUs: videoSource.presentationTimestamp,
+          },
+          this.currentVideoAbortController.signal,
+        )
 
-            if (extractedVideoUrl) {
-              videoElement.src = extractedVideoUrl
-              videoElement.load()
-
-              debugLog('Motion Photo video extracted successfully')
-
-              onLoadingStateUpdate?.({
-                isVisible: false,
-              })
-
-              const result = await new Promise<VideoProcessResult>((resolveVideo) => {
-                const handleVideoCanPlay = () => {
-                  videoElement.removeEventListener('canplaythrough', handleVideoCanPlay)
-                  resolveVideo({
-                    convertedVideoUrl: extractedVideoUrl,
-                    conversionMethod: 'motion-photo-extraction',
-                  })
-                }
-
-                videoElement.addEventListener('canplaythrough', handleVideoCanPlay)
-              })
-
-              resolve(result)
-            } else {
-              throw new Error('Failed to extract Motion Photo video')
-            }
-          } else if (videoSource.type === 'live-photo') {
-            // Live Photo: 处理独立视频文件
-            if (needsVideoConversion(videoSource.videoUrl)) {
-              const result = await this.convertVideo(videoSource.videoUrl, videoElement, callbacks)
-              resolve(result)
-            } else {
-              const result = await this.loadDirectVideo(videoSource.videoUrl, videoElement)
-              resolve(result)
-            }
-          } else {
-            // type === 'none'
-            throw new Error('No video source provided')
-          }
-        } catch (error) {
-          console.error('Failed to process video:', error)
-          onLoadingStateUpdate?.({
-            isVisible: false,
-          })
-          reject(error)
+        if (!extractedVideoUrl) {
+          throw new Error('Failed to extract Motion Photo video')
         }
+
+        this.setVideoSource(videoElement, extractedVideoUrl, { ownedBlobUrl: true })
+        debugLog('Motion Photo video extracted successfully')
+        onLoadingStateUpdate?.({
+          isVisible: false,
+        })
+
+        return await this.waitForVideoReady(videoElement, {
+          convertedVideoUrl: extractedVideoUrl,
+          conversionMethod: 'motion-photo-extraction',
+        })
       }
 
-      // 异步处理视频，不阻塞图片显示
-      processVideo()
-    })
+      if (videoSource.type === 'live-photo') {
+        if (needsVideoConversion(videoSource.videoUrl)) {
+          return await this.convertVideo(videoSource.videoUrl, videoElement, callbacks)
+        }
+
+        return await this.loadDirectVideo(videoSource.videoUrl, videoElement)
+      }
+
+      throw new Error('No video source provided')
+    } catch (error) {
+      console.error('Failed to process video:', error)
+      onLoadingStateUpdate?.({
+        isVisible: false,
+      })
+      throw error
+    }
   }
 
   private async processImageBlob(
@@ -384,32 +497,36 @@ export class ImageLoaderManager {
 
     const i18n = jotaiStore.get(i18nAtom)
 
-    const result = await convertMovToMp4(livePhotoVideoUrl, (progress) => {
-      // 检查是否包含编码器信息（支持多语言）
-      const codecKeywords: string[] = [
-        i18n.t('video.codec.keyword'), // 翻译键
-        'encoder',
-        'codec',
-        '编码器', // 备用关键词
-      ]
-      const isCodecInfo = codecKeywords.some((keyword: string) =>
-        progress.message.toLowerCase().includes(keyword.toLowerCase()),
-      )
+    const result = await convertMovToMp4(
+      livePhotoVideoUrl,
+      (progress) => {
+        // 检查是否包含编码器信息（支持多语言）
+        const codecKeywords: string[] = [
+          i18n.t('video.codec.keyword'), // 翻译键
+          'encoder',
+          'codec',
+          '编码器', // 备用关键词
+        ]
+        const isCodecInfo = codecKeywords.some((keyword: string) =>
+          progress.message.toLowerCase().includes(keyword.toLowerCase()),
+        )
 
-      onLoadingStateUpdate?.({
-        isVisible: true,
-        isConverting: progress.isConverting,
-        loadingProgress: progress.progress,
-        conversionMessage: progress.message,
-        codecInfo: isCodecInfo ? progress.message : undefined,
-      })
-    })
+        onLoadingStateUpdate?.({
+          isVisible: true,
+          isConverting: progress.isConverting,
+          loadingProgress: progress.progress,
+          conversionMessage: progress.message,
+          codecInfo: isCodecInfo ? progress.message : undefined,
+        })
+      },
+      false,
+      { signal: this.currentVideoAbortController?.signal },
+    )
 
     if (result.success && result.videoUrl) {
       const convertedVideoUrl = result.videoUrl
 
-      videoElement.src = result.videoUrl
-      videoElement.load()
+      this.setVideoSource(videoElement, result.videoUrl)
 
       debugLog(
         `Video conversion completed. Size: ${result.convertedSize ? Math.round(result.convertedSize / 1024) : 'unknown'}KB`,
@@ -419,15 +536,8 @@ export class ImageLoaderManager {
         isVisible: false,
       })
 
-      return new Promise((resolve) => {
-        const handleVideoCanPlay = () => {
-          videoElement.removeEventListener('canplaythrough', handleVideoCanPlay)
-          resolve({
-            convertedVideoUrl,
-          })
-        }
-
-        videoElement.addEventListener('canplaythrough', handleVideoCanPlay)
+      return await this.waitForVideoReady(videoElement, {
+        convertedVideoUrl,
       })
     } else {
       console.error('Video conversion failed:', result.error)
@@ -443,18 +553,10 @@ export class ImageLoaderManager {
     videoElement: HTMLVideoElement,
   ): Promise<VideoProcessResult> {
     // 直接使用原始视频
-    videoElement.src = livePhotoVideoUrl
-    videoElement.load()
+    this.setVideoSource(videoElement, livePhotoVideoUrl)
 
-    return new Promise((resolve) => {
-      const handleVideoCanPlay = () => {
-        videoElement.removeEventListener('canplaythrough', handleVideoCanPlay)
-        resolve({
-          conversionMethod: '',
-        })
-      }
-
-      videoElement.addEventListener('canplaythrough', handleVideoCanPlay)
+    return await this.waitForVideoReady(videoElement, {
+      conversionMethod: '',
     })
   }
 
@@ -463,6 +565,12 @@ export class ImageLoaderManager {
     if (this.delayTimer) {
       clearTimeout(this.delayTimer)
       this.delayTimer = null
+
+      if (this.pendingLoadReject) {
+        const rejectLoad = this.pendingLoadReject
+        this.pendingLoadReject = null
+        rejectLoad(createAbortError('Image load cancelled'))
+      }
     }
 
     // 取消正在进行的请求
@@ -470,6 +578,17 @@ export class ImageLoaderManager {
       this.currentXHR.abort()
       this.currentXHR = null
     }
+
+    if (this.currentVideoAbortController) {
+      this.currentVideoAbortController.abort()
+      this.currentVideoAbortController = null
+    }
+
+    if (this.pendingVideoReject) {
+      this.rejectPendingVideo(createAbortError('Video load cancelled'))
+    }
+
+    this.clearVideoElement()
   }
 }
 

--- a/apps/web/src/lib/motion-photo-extractor.ts
+++ b/apps/web/src/lib/motion-photo-extractor.ts
@@ -15,30 +15,40 @@ interface MotionPhotoMetadata {
  * @param metadata Motion Photo 元数据（包含 offset 和可选的 size）
  * @returns 视频的 Blob URL，可直接用于 video 元素
  */
-export async function extractMotionPhotoVideo(imageUrl: string, metadata: MotionPhotoMetadata): Promise<string | null> {
+export async function extractMotionPhotoVideo(
+  imageUrl: string,
+  metadata: MotionPhotoMetadata,
+  signal?: AbortSignal,
+): Promise<string | null> {
   try {
     const { motionPhotoOffset, motionPhotoVideoSize } = metadata
 
     // 尝试使用 Range Request 仅获取视频部分
     if (motionPhotoVideoSize && motionPhotoVideoSize > 0) {
       try {
-        const videoBlob = await fetchVideoWithRange(imageUrl, motionPhotoOffset, motionPhotoVideoSize)
+        const videoBlob = await fetchVideoWithRange(imageUrl, motionPhotoOffset, motionPhotoVideoSize, signal)
         if (videoBlob) {
           return URL.createObjectURL(videoBlob)
         }
       } catch (rangeError) {
+        if (rangeError instanceof Error && rangeError.name === 'AbortError') {
+          throw rangeError
+        }
         console.warn('[motion-photo] Range request failed, falling back to full fetch:', rangeError)
       }
     }
 
     // Fallback: 下载完整图片并提取视频部分
-    const videoBlob = await fetchVideoWithFullDownload(imageUrl, motionPhotoOffset, motionPhotoVideoSize)
+    const videoBlob = await fetchVideoWithFullDownload(imageUrl, motionPhotoOffset, motionPhotoVideoSize, signal)
     if (videoBlob) {
       return URL.createObjectURL(videoBlob)
     }
 
     return null
   } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error
+    }
     console.error('[motion-photo] Failed to extract video:', error)
     return null
   }
@@ -47,9 +57,15 @@ export async function extractMotionPhotoVideo(imageUrl: string, metadata: Motion
 /**
  * 使用 Range Request 获取视频部分（需要服务器支持）
  */
-async function fetchVideoWithRange(imageUrl: string, offset: number, size: number): Promise<Blob | null> {
+async function fetchVideoWithRange(
+  imageUrl: string,
+  offset: number,
+  size: number,
+  signal?: AbortSignal,
+): Promise<Blob | null> {
   const endByte = offset + size - 1
   const response = await fetch(imageUrl, {
+    signal,
     headers: {
       Range: `bytes=${offset}-${endByte}`,
     },
@@ -73,8 +89,13 @@ async function fetchVideoWithRange(imageUrl: string, offset: number, size: numbe
 /**
  * 下载完整图片并提取视频部分（Fallback 方案）
  */
-async function fetchVideoWithFullDownload(imageUrl: string, offset: number, size?: number): Promise<Blob | null> {
-  const response = await fetch(imageUrl)
+async function fetchVideoWithFullDownload(
+  imageUrl: string,
+  offset: number,
+  size?: number,
+  signal?: AbortSignal,
+): Promise<Blob | null> {
+  const response = await fetch(imageUrl, { signal })
   const arrayBuffer = await response.arrayBuffer()
 
   // 提取视频部分

--- a/apps/web/src/lib/mp4-utils.ts
+++ b/apps/web/src/lib/mp4-utils.ts
@@ -16,6 +16,7 @@ interface ConversionResult {
 
 interface TransmuxOptions {
   onProgress?: (progress: ConversionProgress) => void
+  signal?: AbortSignal
 }
 
 /**
@@ -26,6 +27,9 @@ export async function transmuxMovToMp4(videoUrl: string, options: TransmuxOption
   try {
     return await transmuxMovToMp4Simple(videoUrl, options)
   } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error
+    }
     console.error('Transmux error:', error)
     return {
       success: false,
@@ -42,7 +46,7 @@ export async function transmuxMovToMp4Simple(
   videoUrl: string,
   options: TransmuxOptions = {},
 ): Promise<ConversionResult> {
-  const { onProgress } = options
+  const { onProgress, signal } = options
 
   try {
     debugLog('Starting simple transmux conversion')
@@ -55,7 +59,7 @@ export async function transmuxMovToMp4Simple(
     })
 
     // Fetch the video file
-    const response = await fetch(videoUrl)
+    const response = await fetch(videoUrl, { signal })
     if (!response.ok) {
       throw new Error(`Failed to fetch video: ${response.statusText}`)
     }
@@ -103,6 +107,9 @@ export async function transmuxMovToMp4Simple(
       convertedSize: blob.size,
     }
   } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error
+    }
     console.error('Simple transmux error:', error)
     return {
       success: false,

--- a/apps/web/src/lib/video-converter.ts
+++ b/apps/web/src/lib/video-converter.ts
@@ -18,6 +18,10 @@ interface ConversionResult {
   convertedSize?: number
 }
 
+interface ConversionOptions {
+  signal?: AbortSignal
+}
+
 // Global video cache instance using the generic LRU cache with custom cleanup
 const videoCache: LRUCache<string, ConversionResult> = new LRUCache<string, ConversionResult>(
   10,
@@ -36,16 +40,22 @@ const videoCache: LRUCache<string, ConversionResult> = new LRUCache<string, Conv
 function convertMOVtoMP4(
   videoUrl: string,
   onProgress?: (progress: ConversionProgress) => void,
+  options: ConversionOptions = {},
 ): Promise<ConversionResult> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     // Start transmux conversion
     transmuxMovToMp4(videoUrl, {
       onProgress,
+      signal: options.signal,
     })
       .then((result) => {
         resolve(result)
       })
       .catch((error) => {
+        if (error instanceof Error && error.name === 'AbortError') {
+          reject(error)
+          return
+        }
         console.error('Transmux conversion failed:', error)
         resolve({
           success: false,
@@ -99,6 +109,7 @@ export async function convertMovToMp4(
 
   onProgress?: (progress: ConversionProgress) => void,
   forceReconvert = false, // 添加强制重新转换参数
+  options: ConversionOptions = {},
 ): Promise<ConversionResult> {
   const { t } = getI18n()
   // Check cache first, unless forced to reconvert
@@ -127,7 +138,7 @@ export async function convertMovToMp4(
       message: t('video.conversion.transmux.high.quality'),
     })
 
-    const result = await convertMOVtoMP4(videoUrl, onProgress)
+    const result = await convertMOVtoMP4(videoUrl, onProgress, options)
 
     // Cache the result
     videoCache.set(videoUrl, result)
@@ -140,6 +151,9 @@ export async function convertMovToMp4(
 
     return result
   } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error
+    }
     console.error('conversion failed:', error)
     const fallbackResult = {
       success: false,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -66,7 +66,7 @@ const staticWebBuildPlugins: PluginOption[] = [
     workbox: {
       maximumFileSizeToCacheInBytes: 10 * 1024 * 1024, // 10MB
       globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,json}'],
-      globIgnores: ['**/*.{jpg,jpeg}', '**/vendor/heic-*.js'], // 忽略大图片文件和按需 HEIC codec
+      globIgnores: ['**/*.{jpg,jpeg}', '**/vendor/heic-*.js', '**/assets/maplibre-gl-*.js', '**/og-image-*.png'], // 忽略大图片文件、按需 codec、重型地图依赖和历史 OG 图
       runtimeCaching: [
         {
           urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,


### PR DESCRIPTION
## What changed
- fixed image/video loader cleanup so cancelled image requests and Live Photo or Motion Photo video loads settle cleanly instead of leaving hanging work or unreleased media resources
- propagated abort signals through Motion Photo extraction and MOV-to-MP4 conversion so route changes and viewer teardown do not surface false errors
- updated photo sharing fallback so user-cancelled native share does not silently overwrite the clipboard, while real failures still fall back to copying the link
- reduced caching overhead by keeping only the newest generated OG image, excluding heavy map and generated OG assets from Workbox precache, and disabling long-lived cache headers for development-only `/photos` serving

## Why
The photo viewer and masonry Live Photo paths were vulnerable to leaked blob URLs, stale video elements, and ambiguous abort behavior during rapid navigation. The share flow also treated cancelled shares as success, and the PWA config was precaching assets that should stay lazy or ephemeral.

## Impact
- lowers the risk of memory growth and stale media state while browsing many photos
- prevents cancelled media work from showing as real runtime failures
- keeps share behavior aligned with user intent
- reduces unnecessary service worker precache weight and avoids stale local photo caches in development

## Root cause
Cancellation and teardown paths were incomplete across the image loader, Motion Photo extraction path, and video conversion path. Separately, the share fallback conflated cancellation with failure, and the build pipeline retained and precached generated assets too aggressively.

## Validation
- `pnpm type-check`
- `pnpm test`
- `pnpm --filter @afilmory/web type-check`
- `pnpm --filter @afilmory/web test`
- `pnpm --filter @afilmory/web build`
- `pnpm build`
