### PR TITLE
Ignore photos-manifest.json; make GitHub repo sync resilient; clarify Eagle provider live-photo mapping

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const rootIgnores = globalIgnores([
   'apps/ssr/src/index.html.ts',
   'apps/ssr/public/**',
   'apps/web/public/**',
+  'packages/data/src/photos-manifest.json',
 ])
 
 const hyobanConfig = await defineConfig(
@@ -114,7 +115,7 @@ const hyobanConfig = await defineConfig(
   },
 
   // Redundant but harmless: keep a local ignore in case this block is used standalone somewhere
-  globalIgnores(['apps/ssr/src/index.html.ts', 'apps/ssr/public/**', 'apps/web/public/**']),
+  globalIgnores(['apps/ssr/src/index.html.ts', 'apps/ssr/public/**', 'apps/web/public/**', 'packages/data/src/photos-manifest.json']),
 )
 
 export default [

--- a/packages/builder/src/plugins/github-repo-sync.ts
+++ b/packages/builder/src/plugins/github-repo-sync.ts
@@ -9,6 +9,7 @@ import { getBuilderOutputSettings, webAppDir } from '../output-paths.js'
 import type { BuilderPlugin } from './types.js'
 
 const RUN_SHARED_ASSETS_DIR = 'assetsGitDir'
+const RUN_SHARED_SYNC_ENABLED = 'repoSyncEnabled'
 const GIT_ASKPASS_SCRIPT = fileURLToPath(new URL('git-askpass.js', import.meta.url))
 const GIT_HTTP_USERNAME = 'x-access-token'
 
@@ -47,32 +48,39 @@ export default function githubRepoSyncPlugin(options: GitHubRepoSyncPluginOption
 
         logger.main.info('🔄 同步远程仓库...')
 
-        if (!existsSync(assetsGitDir)) {
-          logger.main.info('📥 克隆远程仓库...')
-          await $({
-            cwd: webAppDir,
-            env: gitEnv,
-            stdio: 'inherit',
-          })`git clone ${repo.url} assets-git`
-        } else {
-          logger.main.info('🔄 拉取远程仓库更新...')
-          try {
-            await $({ cwd: assetsGitDir, env: gitEnv, stdio: 'inherit' })`git pull --rebase`
-          } catch {
-            logger.main.warn('⚠️ git pull 失败，尝试重新克隆远程仓库...')
-            logger.main.info('🗑️ 删除现有仓库目录...')
-            await $({ cwd: webAppDir, stdio: 'inherit' })`rm -rf assets-git`
-            logger.main.info('📥 重新克隆远程仓库...')
+        try {
+          if (!existsSync(assetsGitDir)) {
+            logger.main.info('📥 克隆远程仓库...')
             await $({
               cwd: webAppDir,
               env: gitEnv,
               stdio: 'inherit',
             })`git clone ${repo.url} assets-git`
+          } else {
+            logger.main.info('🔄 拉取远程仓库更新...')
+            try {
+              await $({ cwd: assetsGitDir, env: gitEnv, stdio: 'inherit' })`git pull --rebase`
+            } catch {
+              logger.main.warn('⚠️ git pull 失败，尝试重新克隆远程仓库...')
+              logger.main.info('🗑️ 删除现有仓库目录...')
+              await $({ cwd: webAppDir, stdio: 'inherit' })`rm -rf assets-git`
+              logger.main.info('📥 重新克隆远程仓库...')
+              await $({
+                cwd: webAppDir,
+                env: gitEnv,
+                stdio: 'inherit',
+              })`git clone ${repo.url} assets-git`
+            }
           }
-        }
 
-        await prepareRepositoryLayout({ assetsGitDir, logger })
-        logger.main.success('✅ 远程仓库同步完成')
+          await prepareRepositoryLayout({ assetsGitDir, logger })
+          context.runShared.set(RUN_SHARED_SYNC_ENABLED, true)
+          logger.main.success('✅ 远程仓库同步完成')
+        } catch (error) {
+          context.runShared.set(RUN_SHARED_SYNC_ENABLED, false)
+          logger.main.warn('⚠️ 远程仓库同步失败，已降级为本地构建输出（不会中断构建）')
+          logger.main.warn(error instanceof Error ? error.message : String(error))
+        }
       },
       afterBuild: async (context) => {
         const userConfig = context.config.user
@@ -87,9 +95,10 @@ export default function githubRepoSyncPlugin(options: GitHubRepoSyncPluginOption
 
         const { result } = context.payload
         const assetsGitDir = context.runShared.get(RUN_SHARED_ASSETS_DIR) as string | undefined
+        const syncEnabled = context.runShared.get(RUN_SHARED_SYNC_ENABLED) as boolean | undefined
 
-        if (!assetsGitDir) {
-          context.logger.main.warn('⚠️ 未找到仓库目录，跳过推送')
+        if (!syncEnabled || !assetsGitDir) {
+          context.logger.main.warn('⚠️ 远程仓库同步未就绪，跳过推送')
           return
         }
 

--- a/packages/builder/src/storage/providers/eagle-provider.ts
+++ b/packages/builder/src/storage/providers/eagle-provider.ts
@@ -202,8 +202,9 @@ export class EagleStorageProvider implements StorageProvider {
   }
 
   detectLivePhotos(_allObjects: StorageObject[]): Map<string, StorageObject> {
-    // TODO
-    return new Map()
+    // Eagle 数据源当前未暴露与图片稳定绑定的 Live Photo 视频键，
+    // 因此在 Eagle provider 中显式返回空映射。
+    return new Map<string, StorageObject>()
   }
 
   private async copyToDist(key: string) {


### PR DESCRIPTION
### Motivation
- Prevent ESLint from processing a generated manifest file that can cause noisy/linter errors by ignoring `packages/data/src/photos-manifest.json` globally.
- Make the GitHub repository synchronization step robust so failed network/git operations do not abort the overall build and to record whether sync succeeded for later push steps.
- Document and type the Eagle storage provider behavior for Live Photos so callers see an explicit empty mapping instead of a TODO.

### Description
- Added `packages/data/src/photos-manifest.json` to the top-level `rootIgnores` and the local `globalIgnores` array in `eslint.config.mjs` to exclude the generated manifest from linting.
- Wrapped the clone/pull logic in `packages/builder/src/plugins/github-repo-sync.ts` with a `try/catch`, introduced `RUN_SHARED_SYNC_ENABLED` to record sync success in `context.runShared`, and log warnings on failure instead of throwing; the `afterBuild` hook now skips pushing when sync was not enabled.
- Replaced the `TODO` in `EagleStorageProvider.detectLivePhotos` with an explicit empty `Map<string, StorageObject>()` and a clarifying comment in `packages/builder/src/storage/providers/eagle-provider.ts`.

### Testing
- Ran the repository linting (`pnpm lint`) after the ESLint config change and it completed without errors.
- Ran the project test suite (`pnpm test`) and all tests passed.
- Performed a local build (`pnpm build`) to validate the builder plugin and storage provider changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5dc24b2748320ab4edb2e3e58a864)