### PR TITLE
Fix photo route, map return, locale, cache, and tooling regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ generated
 .cursor
 .specstory
 .vscode
+.omx/

--- a/apps/web/src/@types/constants.ts
+++ b/apps/web/src/@types/constants.ts
@@ -1,4 +1,4 @@
-const langs = ['en', 'zh-CN', 'zh-HK', 'jp', 'ko', 'zh-TW'] as const
+const langs = ['en', 'zh-CN', 'zh-HK', 'ja', 'jp', 'ko', 'zh-TW'] as const
 export const currentSupportedLanguages = [...langs].sort() as string[]
 export type MainSupportedLanguages = (typeof langs)[number]
 

--- a/apps/web/src/@types/resources.ts
+++ b/apps/web/src/@types/resources.ts
@@ -17,6 +17,9 @@ export const resources = {
   'zh-HK': {
     app: zhHk,
   },
+  ja: {
+    app: jp,
+  },
   jp: {
     app: jp,
   },

--- a/apps/web/src/components/common/ErrorElement.tsx
+++ b/apps/web/src/components/common/ErrorElement.tsx
@@ -106,7 +106,7 @@ export function ErrorElement() {
                 `### Error\n\n${message}\n\n### Stack\n\n\`\`\`\n${stack}\n\`\`\``,
               )}&label=bug`}
               target="_blank"
-              rel="noreferrer"
+              rel="noreferrer noopener"
               className="text-text-secondary hover:text-text inline-flex items-center text-sm transition-colors"
             >
               <svg className="mr-2 h-4 w-4" fill="currentColor" viewBox="0 0 24 24">

--- a/apps/web/src/components/gallery/CommandPalette.tsx
+++ b/apps/web/src/components/gallery/CommandPalette.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router'
 import { gallerySettingAtom } from '~/atoms/app'
 import { photoLoader } from '~/data-runtime/photo-loader'
 import { fuzzyMatch, getLocationTokens, searchPhotos } from '~/hooks/useCommandSearch'
-import { getViewerPhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { getViewerPhotos, getViewerSourceMode, usePhotoViewer } from '~/hooks/usePhotoViewer'
 import { MageLens } from '~/icons'
 
 // Command types
@@ -243,7 +243,7 @@ export const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
             const viewerPhotos = getViewerPhotos(photo.id)
             const photoIndex = viewerPhotos.findIndex((p) => p.id === photo.id)
             if (photoIndex !== -1) {
-              openViewer(photoIndex)
+              openViewer(photoIndex, { sourceMode: getViewerSourceMode(photo.id) })
               navigate(`/photos/${photo.id}`)
               onClose()
             }

--- a/apps/web/src/components/gallery/CommandPalette.tsx
+++ b/apps/web/src/components/gallery/CommandPalette.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router'
 import { gallerySettingAtom } from '~/atoms/app'
 import { photoLoader } from '~/data-runtime/photo-loader'
 import { fuzzyMatch, getLocationTokens, searchPhotos } from '~/hooks/useCommandSearch'
-import { usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { getViewerPhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
 import { MageLens } from '~/icons'
 
 // Command types
@@ -240,8 +240,8 @@ export const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
           subtitle: photo.description || locationSubtitle || `${photo.exif?.Model || 'Photo'}`,
           icon: <img src={photo.thumbnailUrl} alt={photo.title || 'Photo'} className="h-6 w-6 rounded object-cover" />,
           action: () => {
-            const allPhotos = photoLoader.getPhotos()
-            const photoIndex = allPhotos.findIndex((p) => p.id === photo.id)
+            const viewerPhotos = getViewerPhotos(photo.id)
+            const photoIndex = viewerPhotos.findIndex((p) => p.id === photo.id)
             if (photoIndex !== -1) {
               openViewer(photoIndex)
               navigate(`/photos/${photo.id}`)

--- a/apps/web/src/components/ui/map/ClusterPhotoGrid.tsx
+++ b/apps/web/src/components/ui/map/ClusterPhotoGrid.tsx
@@ -80,7 +80,6 @@ export const ClusterPhotoGrid = ({ photos, onPhotoClick }: ClusterPhotoGridProps
                 pathname: `/photos/${photoMarker.photo.id}`,
                 search: buildPhotoDetailSearch(returnTo),
               }}
-              target="_blank"
               onClick={(e) => {
                 e.stopPropagation()
                 onPhotoClick?.(photoMarker)

--- a/apps/web/src/components/ui/map/ClusterPhotoGrid.tsx
+++ b/apps/web/src/components/ui/map/ClusterPhotoGrid.tsx
@@ -1,8 +1,9 @@
 import { LazyImage, Spring } from '@afilmory/ui'
 import { m } from 'motion/react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router'
+import { Link, useLocation } from 'react-router'
 
+import { buildPhotoDetailSearch } from '~/lib/return-to'
 import type { PhotoMarker } from '~/types/map'
 
 interface ClusterPhotoGridProps {
@@ -16,6 +17,8 @@ export const ClusterPhotoGrid = ({ photos, onPhotoClick }: ClusterPhotoGridProps
   const remainingCount = Math.max(0, photos.length - 6)
   const primaryPhoto = photos[0]
   const { t, i18n } = useTranslation()
+  const location = useLocation()
+  const returnTo = `${location.pathname}${location.search}`
   const locationLabel = primaryPhoto
     ? `${Math.abs(primaryPhoto.latitude).toFixed(4)}°${primaryPhoto.latitudeRef || 'N'}, ${Math.abs(primaryPhoto.longitude).toFixed(4)}°${primaryPhoto.longitudeRef || 'E'}`
     : null
@@ -73,7 +76,10 @@ export const ClusterPhotoGrid = ({ photos, onPhotoClick }: ClusterPhotoGridProps
             className="group relative aspect-square overflow-hidden rounded-lg"
           >
             <Link
-              to={`/photos/${photoMarker.photo.id}`}
+              to={{
+                pathname: `/photos/${photoMarker.photo.id}`,
+                search: buildPhotoDetailSearch(returnTo),
+              }}
               target="_blank"
               onClick={(e) => {
                 e.stopPropagation()

--- a/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
+++ b/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
@@ -126,7 +126,6 @@ export const PhotoMarkerPin = ({ marker, isSelected = false, onClick, onClose }:
                   pathname: `/photos/${marker.photo.id}`,
                   search: buildPhotoDetailSearch(returnTo),
                 }}
-                target="_blank"
                 className="group/link hover:text-blue flex items-center gap-2 transition-colors"
               >
                 <h3

--- a/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
+++ b/apps/web/src/components/ui/map/shared/PhotoMarkerPin.tsx
@@ -2,12 +2,16 @@ import { GlassButton, HoverCard, HoverCardContent, HoverCardTrigger, LazyImage }
 import { m } from 'motion/react'
 import { useTranslation } from 'react-i18next'
 import { Marker } from 'react-map-gl/maplibre'
-import { Link } from 'react-router'
+import { Link, useLocation } from 'react-router'
+
+import { buildPhotoDetailSearch } from '~/lib/return-to'
 
 import type { PhotoMarkerPinProps } from './types'
 
 export const PhotoMarkerPin = ({ marker, isSelected = false, onClick, onClose }: PhotoMarkerPinProps) => {
   const { i18n } = useTranslation()
+  const location = useLocation()
+  const returnTo = `${location.pathname}${location.search}`
 
   const handleClick = () => {
     onClick?.(marker)
@@ -118,7 +122,10 @@ export const PhotoMarkerPin = ({ marker, isSelected = false, onClick, onClose }:
             <div className="space-y-3 p-4">
               {/* Title with link */}
               <Link
-                to={`/photos/${marker.photo.id}`}
+                to={{
+                  pathname: `/photos/${marker.photo.id}`,
+                  search: buildPhotoDetailSearch(returnTo),
+                }}
                 target="_blank"
                 className="group/link hover:text-blue flex items-center gap-2 transition-colors"
               >

--- a/apps/web/src/components/ui/photo-viewer/__tests__/MiniMap.test.tsx
+++ b/apps/web/src/components/ui/photo-viewer/__tests__/MiniMap.test.tsx
@@ -41,6 +41,12 @@ vi.mock('~/lib/map/style', () => ({
 describe('MiniMap', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal(
+      'URL',
+      Object.assign(globalThis.URL ?? {}, {
+        createObjectURL: vi.fn(() => 'blob:mock-url'),
+      }),
+    )
   })
 
   it('renders when one coordinate is zero but the GPS pair is still valid', () => {

--- a/apps/web/src/components/ui/photo-viewer/__tests__/MiniMap.test.tsx
+++ b/apps/web/src/components/ui/photo-viewer/__tests__/MiniMap.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MiniMap } from '../MiniMap'
 
+vi.mock('maplibre-gl', () => ({}))
+
 vi.mock('react-map-gl/maplibre', async () => {
   const React = await import('react')
 

--- a/apps/web/src/hooks/__tests__/viewer-photos.test.ts
+++ b/apps/web/src/hooks/__tests__/viewer-photos.test.ts
@@ -1,0 +1,126 @@
+import type { AfilmoryManifest, PhotoManifestItem } from '@afilmory/data'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type {GallerySetting} from '~/atoms/app';
+import { gallerySettingAtom } from '~/atoms/app'
+import { initializePhotoLoader } from '~/data-runtime/photo-loader'
+import { getFilteredPhotos, getViewerPhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { jotaiStore } from '~/lib/jotai'
+
+const defaultGallerySetting: GallerySetting = {
+  sortBy: 'date',
+  sortOrder: 'desc',
+  selectedTags: [],
+  selectedCameras: [],
+  selectedLenses: [],
+  selectedRatings: null,
+  tagFilterMode: 'union',
+  columns: 'auto',
+}
+
+const createPhoto = (overrides: Partial<PhotoManifestItem>): PhotoManifestItem => ({
+  id: 'photo',
+  title: 'photo',
+  dateTaken: '2026-04-12T00:00:00.000Z',
+  tags: [],
+  description: '',
+  originalUrl: '/photos/photo.jpg',
+  thumbnailUrl: '/thumbnails/photo.jpg',
+  thumbHash: null,
+  width: 1000,
+  height: 800,
+  aspectRatio: 1.25,
+  s3Key: 'photo.jpg',
+  lastModified: '2026-04-12T00:00:00.000Z',
+  size: 1024,
+  exif: null,
+  toneAnalysis: null,
+  location: null,
+  ...overrides,
+})
+
+const manifest: AfilmoryManifest = {
+  version: 'v8',
+  cameras: [],
+  lenses: [],
+  data: [
+    createPhoto({
+      id: 'visible-photo',
+      title: 'Visible Photo',
+      dateTaken: '2026-04-12T00:00:00.000Z',
+      s3Key: 'visible-photo.jpg',
+      originalUrl: '/photos/visible-photo.jpg',
+      thumbnailUrl: '/thumbnails/visible-photo.jpg',
+      tags: ['keep'],
+    }),
+    createPhoto({
+      id: 'hidden-photo',
+      title: 'Hidden Photo',
+      dateTaken: '2026-04-11T00:00:00.000Z',
+      lastModified: '2026-04-11T00:00:00.000Z',
+      s3Key: 'hidden-photo.jpg',
+      originalUrl: '/photos/hidden-photo.jpg',
+      thumbnailUrl: '/thumbnails/hidden-photo.jpg',
+      tags: ['other'],
+    }),
+  ],
+}
+
+describe('viewer photo resolution', () => {
+  beforeEach(() => {
+    initializePhotoLoader(manifest)
+    jotaiStore.set(gallerySettingAtom, defaultGallerySetting)
+  })
+
+  it('keeps the filtered viewer set when the requested photo is still visible', () => {
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      selectedTags: ['keep'],
+    })
+
+    const filteredPhotos = getFilteredPhotos()
+    const viewerPhotos = getViewerPhotos('visible-photo')
+
+    expect(filteredPhotos.map((photo) => photo.id)).toEqual(['visible-photo'])
+    expect(viewerPhotos.map((photo) => photo.id)).toEqual(['visible-photo'])
+  })
+
+  it('falls back to the full photo set when the requested photo is excluded by filters', () => {
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      selectedTags: ['keep'],
+    })
+
+    const filteredPhotos = getFilteredPhotos()
+    const viewerPhotos = getViewerPhotos('hidden-photo')
+
+    expect(filteredPhotos.map((photo) => photo.id)).toEqual(['visible-photo'])
+    expect(viewerPhotos.map((photo) => photo.id)).toEqual(['visible-photo', 'hidden-photo'])
+    expect(viewerPhotos.findIndex((photo) => photo.id === 'hidden-photo')).toBe(1)
+  })
+
+  it('preserves the active sort order when falling back to the full photo set', () => {
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      sortOrder: 'asc',
+      selectedTags: ['keep'],
+    })
+
+    const viewerPhotos = getViewerPhotos('hidden-photo')
+
+    expect(viewerPhotos.map((photo) => photo.id)).toEqual(['hidden-photo', 'visible-photo'])
+    expect(viewerPhotos.findIndex((photo) => photo.id === 'hidden-photo')).toBe(0)
+  })
+
+  it('keeps goToIndex bounded by the active viewer photo count', () => {
+    const { result } = renderHook(() => usePhotoViewer(1))
+
+    act(() => {
+      result.current.openViewer(0)
+      result.current.goToIndex(1)
+    })
+
+    expect(result.current.currentIndex).toBe(0)
+  })
+})

--- a/apps/web/src/hooks/__tests__/viewer-photos.test.ts
+++ b/apps/web/src/hooks/__tests__/viewer-photos.test.ts
@@ -1,11 +1,19 @@
 import type { AfilmoryManifest, PhotoManifestItem } from '@afilmory/data'
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { Provider } from 'jotai'
+import * as React from 'react'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import type {GallerySetting} from '~/atoms/app';
+import type { GallerySetting } from '~/atoms/app'
 import { gallerySettingAtom } from '~/atoms/app'
 import { initializePhotoLoader } from '~/data-runtime/photo-loader'
-import { getFilteredPhotos, getViewerPhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import {
+  getFilteredPhotos,
+  getViewerPhotos,
+  getViewerSourceMode,
+  usePhotoViewer,
+  useViewerPhotos,
+} from '~/hooks/usePhotoViewer'
 import { jotaiStore } from '~/lib/jotai'
 
 const defaultGallerySetting: GallerySetting = {
@@ -67,10 +75,19 @@ const manifest: AfilmoryManifest = {
   ],
 }
 
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(Provider, { store: jotaiStore }, children)
+
 describe('viewer photo resolution', () => {
   beforeEach(() => {
     initializePhotoLoader(manifest)
     jotaiStore.set(gallerySettingAtom, defaultGallerySetting)
+
+    const { result, unmount } = renderHook(() => usePhotoViewer(), { wrapper })
+    act(() => {
+      result.current.closeViewer()
+    })
+    unmount()
   })
 
   it('keeps the filtered viewer set when the requested photo is still visible', () => {
@@ -114,13 +131,47 @@ describe('viewer photo resolution', () => {
   })
 
   it('keeps goToIndex bounded by the active viewer photo count', () => {
-    const { result } = renderHook(() => usePhotoViewer(1))
+    const { result } = renderHook(() => usePhotoViewer(1), { wrapper })
 
     act(() => {
-      result.current.openViewer(0)
+      result.current.openViewer(0, { sourceMode: 'filtered' })
       result.current.goToIndex(1)
     })
 
     expect(result.current.currentIndex).toBe(0)
+  })
+
+  it('keeps an all-photos viewer session stable after navigating to a visible filtered photo', async () => {
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      selectedTags: ['keep'],
+    })
+
+    const { result, rerender } = renderHook(
+      ({ photoId }) => {
+        const photos = useViewerPhotos(photoId)
+        const viewer = usePhotoViewer(photos.length)
+        return { photos, viewer }
+      },
+      { initialProps: { photoId: 'hidden-photo' as string | null }, wrapper },
+    )
+
+    act(() => {
+      result.current.viewer.openViewer(1, { sourceMode: getViewerSourceMode('hidden-photo') })
+    })
+
+    rerender({ photoId: 'visible-photo' })
+    expect(result.current.photos.map((photo) => photo.id)).toEqual(['visible-photo', 'hidden-photo'])
+    expect(result.current.viewer.viewerSourceMode).toBe('all')
+
+    act(() => {
+      result.current.viewer.closeViewer()
+    })
+
+    rerender({ photoId: 'visible-photo' })
+    await waitFor(() => {
+      expect(result.current.photos.map((photo) => photo.id)).toEqual(['visible-photo'])
+      expect(result.current.viewer.viewerSourceMode).toBeNull()
+    })
   })
 })

--- a/apps/web/src/hooks/__tests__/viewer-photos.test.ts
+++ b/apps/web/src/hooks/__tests__/viewer-photos.test.ts
@@ -174,4 +174,40 @@ describe('viewer photo resolution', () => {
       expect(result.current.viewer.viewerSourceMode).toBeNull()
     })
   })
+
+  it('falls back to all photos when a filtered viewer session loses the active photo', () => {
+    const { result: viewerResult } = renderHook(() => usePhotoViewer(), { wrapper })
+    const { result, rerender } = renderHook(({ photoId }) => useViewerPhotos(photoId), {
+      initialProps: { photoId: 'hidden-photo' as string | null },
+      wrapper,
+    })
+
+    act(() => {
+      viewerResult.current.openViewer(1, { sourceMode: 'filtered' })
+    })
+
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      selectedTags: ['keep'],
+    })
+
+    rerender({ photoId: 'hidden-photo' })
+    expect(result.current.map((photo) => photo.id)).toEqual(['visible-photo', 'hidden-photo'])
+  })
+
+  it('keeps goToIndex bounded by the filtered viewer count when no explicit photoCount is provided', () => {
+    jotaiStore.set(gallerySettingAtom, {
+      ...defaultGallerySetting,
+      selectedTags: ['keep'],
+    })
+
+    const { result } = renderHook(() => usePhotoViewer(), { wrapper })
+
+    act(() => {
+      result.current.openViewer(0, { sourceMode: 'filtered' })
+      result.current.goToIndex(1)
+    })
+
+    expect(result.current.currentIndex).toBe(0)
+  })
 })

--- a/apps/web/src/hooks/usePhotoViewer.ts
+++ b/apps/web/src/hooks/usePhotoViewer.ts
@@ -10,6 +10,9 @@ import { PhotosContext } from '~/providers/photos-provider'
 const openAtom = atom(false)
 const currentIndexAtom = atom(0)
 const triggerElementAtom = atom<HTMLElement | null>(null)
+const viewerSourceModeAtom = atom<ViewerSourceMode | null>(null)
+
+type ViewerSourceMode = 'filtered' | 'all'
 
 const getAllPhotos = () => photoLoader.getPhotos()
 const sortPhotos = (photos: ReturnType<typeof getAllPhotos>, sortOrder: 'asc' | 'desc') => {
@@ -89,16 +92,26 @@ const getAllPhotosForViewer = (sortOrder: 'asc' | 'desc') => {
   return sortPhotos(getAllPhotos(), sortOrder)
 }
 
+const resolveViewerSourceMode = (
+  photoId: string | null | undefined,
+  filteredPhotos: ReturnType<typeof getFilteredPhotos>,
+): ViewerSourceMode => {
+  if (!photoId) {
+    return 'filtered'
+  }
+
+  return filteredPhotos.some((photo) => photo.id === photoId) ? 'filtered' : 'all'
+}
+
 const resolveViewerPhotos = (
   photoId: string | null | undefined,
   filteredPhotos: ReturnType<typeof getFilteredPhotos>,
   sortOrder: 'asc' | 'desc',
+  viewerSourceMode?: ViewerSourceMode | null,
 ) => {
-  if (!photoId) {
-    return filteredPhotos
-  }
+  const sourceMode = viewerSourceMode ?? resolveViewerSourceMode(photoId, filteredPhotos)
 
-  return filteredPhotos.some((photo) => photo.id === photoId) ? filteredPhotos : getAllPhotosForViewer(sortOrder)
+  return sourceMode === 'all' ? getAllPhotosForViewer(sortOrder) : filteredPhotos
 }
 
 // 提供一个 getter 函数供非 UI 组件使用
@@ -117,7 +130,14 @@ export const getFilteredPhotos = () => {
 
 export const getViewerPhotos = (photoId?: string | null) => {
   const { sortOrder } = jotaiStore.get(gallerySettingAtom)
-  return resolveViewerPhotos(photoId, getFilteredPhotos(), sortOrder)
+  const filteredPhotos = getFilteredPhotos()
+  const viewerSourceMode = jotaiStore.get(openAtom) ? jotaiStore.get(viewerSourceModeAtom) : null
+
+  return resolveViewerPhotos(photoId, filteredPhotos, sortOrder, viewerSourceMode)
+}
+
+export const getViewerSourceMode = (photoId?: string | null) => {
+  return resolveViewerSourceMode(photoId, getFilteredPhotos())
 }
 
 export const usePhotos = () => {
@@ -133,9 +153,14 @@ export const usePhotos = () => {
 
 export const useViewerPhotos = (photoId?: string | null) => {
   const { sortOrder } = useAtomValue(gallerySettingAtom)
+  const isOpen = useAtomValue(openAtom)
+  const viewerSourceMode = useAtomValue(viewerSourceModeAtom)
   const filteredPhotos = usePhotos()
 
-  return useMemo(() => resolveViewerPhotos(photoId, filteredPhotos, sortOrder), [filteredPhotos, photoId, sortOrder])
+  return useMemo(
+    () => resolveViewerPhotos(photoId, filteredPhotos, sortOrder, isOpen ? viewerSourceMode : null),
+    [filteredPhotos, isOpen, photoId, sortOrder, viewerSourceMode],
+  )
 }
 
 export const useContextPhotos = () => {
@@ -150,24 +175,27 @@ export const usePhotoViewer = (photoCount?: number) => {
   const [isOpen, setIsOpen] = useAtom(openAtom)
   const [currentIndex, setCurrentIndex] = useAtom(currentIndexAtom)
   const [triggerElement, setTriggerElement] = useAtom(triggerElementAtom)
+  const [viewerSourceMode, setViewerSourceMode] = useAtom(viewerSourceModeAtom)
 
   const openViewer = useCallback(
-    (index: number, element?: HTMLElement) => {
+    (index: number, options?: { element?: HTMLElement | null; sourceMode?: ViewerSourceMode }) => {
       setCurrentIndex(index)
-      setTriggerElement(element || null)
+      setTriggerElement(options?.element || null)
+      setViewerSourceMode(options?.sourceMode ?? null)
       setIsOpen(true)
       // 防止背景滚动
       document.body.style.overflow = 'hidden'
     },
-    [setCurrentIndex, setIsOpen, setTriggerElement],
+    [setCurrentIndex, setIsOpen, setTriggerElement, setViewerSourceMode],
   )
 
   const closeViewer = useCallback(() => {
     setIsOpen(false)
     setTriggerElement(null)
+    setViewerSourceMode(null)
     // 恢复背景滚动
     document.body.style.overflow = ''
-  }, [setIsOpen, setTriggerElement])
+  }, [setIsOpen, setTriggerElement, setViewerSourceMode])
 
   const goToIndex = useCallback(
     (index: number) => {
@@ -183,6 +211,7 @@ export const usePhotoViewer = (photoCount?: number) => {
     isOpen,
     currentIndex,
     triggerElement,
+    viewerSourceMode,
     openViewer,
     closeViewer,
 

--- a/apps/web/src/hooks/usePhotoViewer.ts
+++ b/apps/web/src/hooks/usePhotoViewer.ts
@@ -11,6 +11,16 @@ const openAtom = atom(false)
 const currentIndexAtom = atom(0)
 const triggerElementAtom = atom<HTMLElement | null>(null)
 
+const getAllPhotos = () => photoLoader.getPhotos()
+const sortPhotos = (photos: ReturnType<typeof getAllPhotos>, sortOrder: 'asc' | 'desc') => {
+  return photos.toSorted((a, b) => {
+    const aDateStr = getPhotoDateString(a)
+    const bDateStr = getPhotoDateString(b)
+
+    return sortOrder === 'asc' ? aDateStr.localeCompare(bDateStr) : bDateStr.localeCompare(aDateStr)
+  })
+}
+
 // 抽取照片筛选和排序逻辑为独立函数
 const filterAndSortPhotos = (
   selectedTags: string[],
@@ -70,14 +80,25 @@ const filterAndSortPhotos = (
   }
 
   // 然后排序
-  const sortedPhotos = filteredPhotos.toSorted((a, b) => {
-    const aDateStr = getPhotoDateString(a)
-    const bDateStr = getPhotoDateString(b)
-
-    return sortOrder === 'asc' ? aDateStr.localeCompare(bDateStr) : bDateStr.localeCompare(aDateStr)
-  })
+  const sortedPhotos = sortPhotos(filteredPhotos, sortOrder)
 
   return sortedPhotos
+}
+
+const getAllPhotosForViewer = (sortOrder: 'asc' | 'desc') => {
+  return sortPhotos(getAllPhotos(), sortOrder)
+}
+
+const resolveViewerPhotos = (
+  photoId: string | null | undefined,
+  filteredPhotos: ReturnType<typeof getFilteredPhotos>,
+  sortOrder: 'asc' | 'desc',
+) => {
+  if (!photoId) {
+    return filteredPhotos
+  }
+
+  return filteredPhotos.some((photo) => photo.id === photoId) ? filteredPhotos : getAllPhotosForViewer(sortOrder)
 }
 
 // 提供一个 getter 函数供非 UI 组件使用
@@ -94,6 +115,11 @@ export const getFilteredPhotos = () => {
   )
 }
 
+export const getViewerPhotos = (photoId?: string | null) => {
+  const { sortOrder } = jotaiStore.get(gallerySettingAtom)
+  return resolveViewerPhotos(photoId, getFilteredPhotos(), sortOrder)
+}
+
 export const usePhotos = () => {
   const { sortOrder, selectedTags, selectedCameras, selectedLenses, selectedRatings, tagFilterMode } =
     useAtomValue(gallerySettingAtom)
@@ -105,6 +131,13 @@ export const usePhotos = () => {
   return masonryItems
 }
 
+export const useViewerPhotos = (photoId?: string | null) => {
+  const { sortOrder } = useAtomValue(gallerySettingAtom)
+  const filteredPhotos = usePhotos()
+
+  return useMemo(() => resolveViewerPhotos(photoId, filteredPhotos, sortOrder), [filteredPhotos, photoId, sortOrder])
+}
+
 export const useContextPhotos = () => {
   const photos = use(PhotosContext)
   if (!photos) {
@@ -113,8 +146,7 @@ export const useContextPhotos = () => {
   return photos
 }
 
-export const usePhotoViewer = () => {
-  const photos = usePhotos()
+export const usePhotoViewer = (photoCount?: number) => {
   const [isOpen, setIsOpen] = useAtom(openAtom)
   const [currentIndex, setCurrentIndex] = useAtom(currentIndexAtom)
   const [triggerElement, setTriggerElement] = useAtom(triggerElementAtom)
@@ -139,11 +171,12 @@ export const usePhotoViewer = () => {
 
   const goToIndex = useCallback(
     (index: number) => {
-      if (index >= 0 && index < photos.length) {
+      const maxPhotoCount = photoCount ?? getAllPhotos().length
+      if (index >= 0 && index < maxPhotoCount) {
         setCurrentIndex(index)
       }
     },
-    [photos, setCurrentIndex],
+    [photoCount, setCurrentIndex],
   )
 
   return {

--- a/apps/web/src/hooks/usePhotoViewer.ts
+++ b/apps/web/src/hooks/usePhotoViewer.ts
@@ -109,7 +109,10 @@ const resolveViewerPhotos = (
   sortOrder: 'asc' | 'desc',
   viewerSourceMode?: ViewerSourceMode | null,
 ) => {
-  const sourceMode = viewerSourceMode ?? resolveViewerSourceMode(photoId, filteredPhotos)
+  const sourceMode =
+    viewerSourceMode === 'filtered' && photoId && !filteredPhotos.some((photo) => photo.id === photoId)
+      ? 'all'
+      : (viewerSourceMode ?? resolveViewerSourceMode(photoId, filteredPhotos))
 
   return sourceMode === 'all' ? getAllPhotosForViewer(sortOrder) : filteredPhotos
 }
@@ -199,12 +202,13 @@ export const usePhotoViewer = (photoCount?: number) => {
 
   const goToIndex = useCallback(
     (index: number) => {
-      const maxPhotoCount = photoCount ?? getAllPhotos().length
+      const maxPhotoCount =
+        photoCount ?? (viewerSourceMode === 'all' ? getAllPhotos().length : getFilteredPhotos().length)
       if (index >= 0 && index < maxPhotoCount) {
         setCurrentIndex(index)
       }
     },
-    [photoCount, setCurrentIndex],
+    [photoCount, setCurrentIndex, viewerSourceMode],
   )
 
   return {

--- a/apps/web/src/lib/__tests__/return-to.test.ts
+++ b/apps/web/src/lib/__tests__/return-to.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPhotoDetailSearch, getSafeReturnTo } from '~/lib/return-to'
+
+describe('return-to helpers', () => {
+  it('builds a returnTo query string for internal routes', () => {
+    expect(buildPhotoDetailSearch('/explore?photoId=A7C09524')).toBe('?returnTo=%2Fexplore%3FphotoId%3DA7C09524')
+  })
+
+  it('reads back safe internal return targets', () => {
+    expect(getSafeReturnTo('?returnTo=%2Fexplore%3FphotoId%3DA7C09524')).toBe('/explore?photoId=A7C09524')
+  })
+
+  it('rejects external or protocol-relative return targets', () => {
+    expect(getSafeReturnTo('?returnTo=https%3A%2F%2Fevil.example')).toBeNull()
+    expect(getSafeReturnTo('?returnTo=%2F%2Fevil.example')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/__tests__/return-to.test.ts
+++ b/apps/web/src/lib/__tests__/return-to.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildPhotoDetailSearch, getSafeReturnTo } from '~/lib/return-to'
+import { buildPhotoDetailSearch, getSafeReturnTo, syncPhotoDetailSearch } from '~/lib/return-to'
 
 describe('return-to helpers', () => {
   it('builds a returnTo query string for internal routes', () => {
@@ -19,5 +19,11 @@ describe('return-to helpers', () => {
   it('rejects internal paths outside the allowed browse surfaces', () => {
     expect(getSafeReturnTo('?returnTo=%2Fphotos%2FA7C09524')).toBeNull()
     expect(getSafeReturnTo('?returnTo=%2F')).toBeNull()
+  })
+
+  it('keeps nested explore photoId in sync with the active photo', () => {
+    expect(syncPhotoDetailSearch('?returnTo=%2Fexplore%3FphotoId%3DA7C09524', 'A7C01202')).toBe(
+      '?returnTo=%2Fexplore%3FphotoId%3DA7C01202',
+    )
   })
 })

--- a/apps/web/src/lib/__tests__/return-to.test.ts
+++ b/apps/web/src/lib/__tests__/return-to.test.ts
@@ -15,4 +15,9 @@ describe('return-to helpers', () => {
     expect(getSafeReturnTo('?returnTo=https%3A%2F%2Fevil.example')).toBeNull()
     expect(getSafeReturnTo('?returnTo=%2F%2Fevil.example')).toBeNull()
   })
+
+  it('rejects internal paths outside the allowed browse surfaces', () => {
+    expect(getSafeReturnTo('?returnTo=%2Fphotos%2FA7C09524')).toBeNull()
+    expect(getSafeReturnTo('?returnTo=%2F')).toBeNull()
+  })
 })

--- a/apps/web/src/lib/return-to.ts
+++ b/apps/web/src/lib/return-to.ts
@@ -1,0 +1,22 @@
+const RETURN_TO_PARAM = 'returnTo'
+
+export function buildPhotoDetailSearch(returnTo: string): string {
+  const searchParams = new URLSearchParams()
+  searchParams.set(RETURN_TO_PARAM, returnTo)
+  return `?${searchParams.toString()}`
+}
+
+export function getSafeReturnTo(search: string): string | null {
+  const searchParams = new URLSearchParams(search)
+  const returnTo = searchParams.get(RETURN_TO_PARAM)
+
+  if (!returnTo) {
+    return null
+  }
+
+  if (!returnTo.startsWith('/') || returnTo.startsWith('//')) {
+    return null
+  }
+
+  return returnTo
+}

--- a/apps/web/src/lib/return-to.ts
+++ b/apps/web/src/lib/return-to.ts
@@ -7,10 +7,38 @@ export function buildPhotoDetailSearch(returnTo: string): string {
   return `?${searchParams.toString()}`
 }
 
+export function syncPhotoDetailSearch(search: string, photoId: string): string {
+  const searchParams = new URLSearchParams(search)
+  const returnTo = searchParams.get(RETURN_TO_PARAM)
+
+  if (!returnTo) {
+    return search
+  }
+
+  const returnUrl = getSafeReturnToUrl(returnTo)
+  if (!returnUrl || returnUrl.pathname !== '/explore') {
+    return search
+  }
+
+  returnUrl.searchParams.set('photoId', photoId)
+  searchParams.set(RETURN_TO_PARAM, `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`)
+
+  return `?${searchParams.toString()}`
+}
+
 export function getSafeReturnTo(search: string): string | null {
   const searchParams = new URLSearchParams(search)
   const returnTo = searchParams.get(RETURN_TO_PARAM)
 
+  const returnUrl = getSafeReturnToUrl(returnTo)
+  if (!returnUrl) {
+    return null
+  }
+
+  return `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`
+}
+
+function getSafeReturnToUrl(returnTo: string | null): URL | null {
   if (!returnTo) {
     return null
   }
@@ -24,5 +52,5 @@ export function getSafeReturnTo(search: string): string | null {
     return null
   }
 
-  return `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`
+  return returnUrl
 }

--- a/apps/web/src/lib/return-to.ts
+++ b/apps/web/src/lib/return-to.ts
@@ -1,4 +1,5 @@
 const RETURN_TO_PARAM = 'returnTo'
+const ALLOWED_RETURN_TO_PATHNAMES = new Set(['/explore'])
 
 export function buildPhotoDetailSearch(returnTo: string): string {
   const searchParams = new URLSearchParams()
@@ -18,5 +19,10 @@ export function getSafeReturnTo(search: string): string | null {
     return null
   }
 
-  return returnTo
+  const returnUrl = new URL(returnTo, 'https://afilmory.local')
+  if (!ALLOWED_RETURN_TO_PATHNAMES.has(returnUrl.pathname)) {
+    return null
+  }
+
+  return `${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`
 }

--- a/apps/web/src/modules/gallery/MasonryHeaderMasonryItem.tsx
+++ b/apps/web/src/modules/gallery/MasonryHeaderMasonryItem.tsx
@@ -52,7 +52,7 @@ export const MasonryHeaderMasonryItem = ({ style, className }: { style?: React.C
               <a
                 href={`https://github.com/${siteConfig.social.github}`}
                 target="_blank"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 className="text-text-secondary flex items-center justify-center p-2 duration-200 hover:text-[#E7E8E8]"
                 title="GitHub"
               >
@@ -63,7 +63,7 @@ export const MasonryHeaderMasonryItem = ({ style, className }: { style?: React.C
               <a
                 href={`https://twitter.com/${siteConfig.social.twitter.replace('@', '')}`}
                 target="_blank"
-                rel="noreferrer"
+                rel="noreferrer noopener"
                 className="text-text-secondary flex items-center justify-center p-2 duration-200 hover:text-[#1da1f2]"
                 title="Twitter"
               >
@@ -74,6 +74,7 @@ export const MasonryHeaderMasonryItem = ({ style, className }: { style?: React.C
               <a
                 href="/feed.xml"
                 target="_blank"
+                rel="noreferrer noopener"
                 className="text-text-secondary flex items-center justify-center p-2 duration-200 hover:text-[#ec672c]"
                 title="RSS"
               >
@@ -110,7 +111,7 @@ export const MasonryHeaderMasonryItem = ({ style, className }: { style?: React.C
                 <a
                   href={`${repository.url}/commit/${GIT_COMMIT_HASH}`}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noreferrer noopener"
                   className="text-gray-500 dark:text-gray-400"
                 >
                   {GIT_COMMIT_HASH.slice(0, 6)}

--- a/apps/web/src/modules/gallery/MasonryPhotoItem.tsx
+++ b/apps/web/src/modules/gallery/MasonryPhotoItem.tsx
@@ -64,7 +64,7 @@ export const MasonryPhotoItem = memo(
         const triggerEl =
           imageRef.current?.parentElement instanceof HTMLElement ? imageRef.current.parentElement : imageRef.current
 
-        photoViewer.openViewer(photoIndex, triggerEl ?? undefined)
+        photoViewer.openViewer(photoIndex, { element: triggerEl ?? undefined, sourceMode: 'filtered' })
       }
     }
 

--- a/apps/web/src/pages/(main)/layout.tsx
+++ b/apps/web/src/pages/(main)/layout.tsx
@@ -6,7 +6,7 @@ import { Outlet, useLocation, useNavigate, useParams, useSearchParams } from 're
 import { gallerySettingAtom } from '~/atoms/app'
 import { siteConfig } from '~/config'
 import { useMobile } from '~/hooks/useMobile'
-import { getViewerPhotos, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { getViewerPhotos, getViewerSourceMode, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
 import { MasonryRoot } from '~/modules/gallery/MasonryRoot'
 import { PhotosProvider } from '~/providers/photos-provider'
 
@@ -93,7 +93,7 @@ const useStateRestoreFromUrl = () => {
       const photos = getViewerPhotos(photoId)
       const index = photos.findIndex((photo) => photo.id === photoId)
       if (index !== -1) {
-        openViewer(index)
+        openViewer(index, { sourceMode: getViewerSourceMode(photoId) })
       }
     }
   }, [openViewer, photoId, searchParams, setGallerySetting])

--- a/apps/web/src/pages/(main)/layout.tsx
+++ b/apps/web/src/pages/(main)/layout.tsx
@@ -6,7 +6,7 @@ import { Outlet, useLocation, useNavigate, useParams, useSearchParams } from 're
 import { gallerySettingAtom } from '~/atoms/app'
 import { siteConfig } from '~/config'
 import { useMobile } from '~/hooks/useMobile'
-import { getFilteredPhotos, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { getViewerPhotos, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
 import { MasonryRoot } from '~/modules/gallery/MasonryRoot'
 import { PhotosProvider } from '~/providers/photos-provider'
 
@@ -90,7 +90,7 @@ const useStateRestoreFromUrl = () => {
     // 如果 URL 中有 photoId，打开查看器
     // 找到对应的照片索引，确保 currentIndex 和 URL 保持一致
     if (photoId) {
-      const photos = getFilteredPhotos()
+      const photos = getViewerPhotos(photoId)
       const index = photos.findIndex((photo) => photo.id === photoId)
       if (index !== -1) {
         openViewer(index)
@@ -107,6 +107,7 @@ const useSyncStateToUrl = () => {
   const navigate = useNavigate()
 
   const location = useLocation()
+  const { photoId } = useParams()
   const { isOpen, currentIndex } = usePhotoViewer()
 
   useEffect(() => {
@@ -117,7 +118,7 @@ const useSyncStateToUrl = () => {
 
     if (isOpen) {
       wasOpenRef.current = true
-      const photos = getFilteredPhotos()
+      const photos = getViewerPhotos(photoId)
       // 确保 currentIndex 在有效范围内，避免筛选条件变化时数组越界
       if (currentIndex >= 0 && currentIndex < photos.length) {
         const targetPathname = `/photos/${photos[currentIndex].id}`
@@ -138,7 +139,7 @@ const useSyncStateToUrl = () => {
       }, 500)
       return () => clearTimeout(timer)
     }
-  }, [currentIndex, isOpen, location.pathname, navigate])
+  }, [currentIndex, isOpen, location.pathname, navigate, photoId])
 
   useEffect(() => {
     if (!isRestored) return

--- a/apps/web/src/pages/(main)/layout.tsx
+++ b/apps/web/src/pages/(main)/layout.tsx
@@ -7,7 +7,7 @@ import { gallerySettingAtom } from '~/atoms/app'
 import { siteConfig } from '~/config'
 import { useMobile } from '~/hooks/useMobile'
 import { getViewerPhotos, getViewerSourceMode, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
-import { getSafeReturnTo } from '~/lib/return-to'
+import { getSafeReturnTo, syncPhotoDetailSearch } from '~/lib/return-to'
 import { MasonryRoot } from '~/modules/gallery/MasonryRoot'
 import { PhotosProvider } from '~/providers/photos-provider'
 
@@ -122,10 +122,12 @@ const useSyncStateToUrl = () => {
       const photos = getViewerPhotos(photoId)
       // 确保 currentIndex 在有效范围内，避免筛选条件变化时数组越界
       if (currentIndex >= 0 && currentIndex < photos.length) {
-        const targetPathname = `/photos/${photos[currentIndex].id}`
-        if (location.pathname !== targetPathname) {
+        const targetPhotoId = photos[currentIndex].id
+        const targetPathname = `/photos/${targetPhotoId}`
+        const targetSearch = syncPhotoDetailSearch(location.search, targetPhotoId)
+        if (location.pathname !== targetPathname || location.search !== targetSearch) {
           // 使用 replace 避免在浏览器历史中堆积过多记录
-          navigate({ pathname: targetPathname, search: location.search }, { replace: true })
+          navigate({ pathname: targetPathname, search: targetSearch }, { replace: true })
         }
       }
       return

--- a/apps/web/src/pages/(main)/layout.tsx
+++ b/apps/web/src/pages/(main)/layout.tsx
@@ -7,6 +7,7 @@ import { gallerySettingAtom } from '~/atoms/app'
 import { siteConfig } from '~/config'
 import { useMobile } from '~/hooks/useMobile'
 import { getViewerPhotos, getViewerSourceMode, usePhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { getSafeReturnTo } from '~/lib/return-to'
 import { MasonryRoot } from '~/modules/gallery/MasonryRoot'
 import { PhotosProvider } from '~/providers/photos-provider'
 
@@ -124,7 +125,7 @@ const useSyncStateToUrl = () => {
         const targetPathname = `/photos/${photos[currentIndex].id}`
         if (location.pathname !== targetPathname) {
           // 使用 replace 避免在浏览器历史中堆积过多记录
-          navigate(targetPathname, { replace: true })
+          navigate({ pathname: targetPathname, search: location.search }, { replace: true })
         }
       }
       return
@@ -134,12 +135,13 @@ const useSyncStateToUrl = () => {
     wasOpenRef.current = false
 
     if (justClosedViewer && isPhotoDetailPath && !isExplorePath) {
+      const returnTo = getSafeReturnTo(location.search)
       const timer = setTimeout(() => {
-        navigate('/', { replace: true })
+        navigate(returnTo || '/', { replace: true })
       }, 500)
       return () => clearTimeout(timer)
     }
-  }, [currentIndex, isOpen, location.pathname, navigate, photoId])
+  }, [currentIndex, isOpen, location.pathname, location.search, navigate, photoId])
 
   useEffect(() => {
     if (!isRestored) return

--- a/apps/web/src/pages/(main)/layout.tsx
+++ b/apps/web/src/pages/(main)/layout.tsx
@@ -102,7 +102,7 @@ const useStateRestoreFromUrl = () => {
 
 const useSyncStateToUrl = () => {
   const wasOpenRef = useRef(false)
-  const { selectedTags, selectedCameras, selectedLenses, selectedRatings, tagFilterMode } =
+  const { selectedTags, selectedCameras, selectedLenses, selectedRatings, sortOrder, tagFilterMode } =
     useAtomValue(gallerySettingAtom)
   const [_, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -143,7 +143,20 @@ const useSyncStateToUrl = () => {
       }, 500)
       return () => clearTimeout(timer)
     }
-  }, [currentIndex, isOpen, location.pathname, location.search, navigate, photoId])
+  }, [
+    currentIndex,
+    isOpen,
+    location.pathname,
+    location.search,
+    navigate,
+    photoId,
+    selectedTags,
+    selectedCameras,
+    selectedLenses,
+    selectedRatings,
+    sortOrder,
+    tagFilterMode,
+  ])
 
   useEffect(() => {
     if (!isRestored) return

--- a/apps/web/src/pages/(main)/photos/[photoId]/index.tsx
+++ b/apps/web/src/pages/(main)/photos/[photoId]/index.tsx
@@ -6,15 +6,15 @@ import { useParams } from 'react-router'
 
 import { NotFound } from '~/components/common/NotFound'
 import { PhotoViewer } from '~/components/ui/photo-viewer'
-import { useContextPhotos, usePhotoViewer } from '~/hooks/usePhotoViewer'
+import { usePhotoViewer, useViewerPhotos } from '~/hooks/usePhotoViewer'
 import { useTitle } from '~/hooks/useTitle'
 import { applyAccentTransitionStyle } from '~/lib/accent-transition-style'
 import { deriveAccentFromSources } from '~/lib/color'
 
 export const Component = () => {
   const { photoId } = useParams()
-  const photoViewer = usePhotoViewer()
-  const photos = useContextPhotos()
+  const photos = useViewerPhotos(photoId)
+  const photoViewer = usePhotoViewer(photos.length)
 
   // 直接根据 photoId 从 Context 的照片列表中查找照片和索引
   const photoIndex = useMemo(() => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -247,7 +247,7 @@ export default defineConfig(async ({ command }) => {
     define: {
       APP_DEV_CWD: JSON.stringify(process.cwd()),
       APP_NAME: JSON.stringify(PKG.name),
-      BUILT_DATE: JSON.stringify(new Date().toLocaleDateString()),
+      BUILT_DATE: JSON.stringify(new Date().toISOString()),
       GIT_COMMIT_HASH: JSON.stringify(getGitHash()),
     },
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,12 @@
 {
+  "files": [],
+  "references": [
+    { "path": "./apps/web/tsconfig.json" },
+    { "path": "./packages/builder/tsconfig.json" },
+    { "path": "./packages/data/tsconfig.json" },
+    { "path": "./packages/ui/tsconfig.json" },
+    { "path": "./packages/webgl-viewer/tsconfig.json" }
+  ],
   "compilerOptions": {
     "target": "ESNext",
     "lib": [

--- a/vercel.json
+++ b/vercel.json
@@ -76,7 +76,7 @@
       ]
     },
     {
-      "source": "/(feed\\.json|sitemap\\.xml)",
+      "source": "/(feed\\.xml|sitemap\\.xml)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- fix photo detail and command-palette navigation when active filters exclude the target photo
- preserve map -> photo -> close context, including adjacent photo browsing from map-origin sessions
- normalize Japanese locale handling by supporting standard `ja` while keeping legacy `jp` compatibility
- fix `feed.xml` cache headers, serialize build dates as ISO, and harden remaining `_blank` links
- turn the root `tsconfig.json` into a solution-style workspace entry and stabilize MiniMap tests in jsdom

## Key fixes
- photo detail pages no longer degrade into NotFound just because current gallery filters exclude the target photo
- command palette search opens the correct photo/viewer source set under active filters
- map-origin photo navigation now returns to `/explore` context instead of dropping to `/`
- map return targets stay synced while browsing adjacent photos from a map-origin session
- `?lng=ja` now correctly renders Japanese UI strings
- `feed.xml` now uses short revalidation instead of falling through to immutable XML caching
- build date metadata is serialized in a machine-safe format before locale-specific rendering
- remaining new-tab links now declare `rel="noreferrer noopener"`
- root-level TypeScript diagnostics now resolve cleanly through package references
- MiniMap tests no longer emit jsdom-specific unhandled URL/createObjectURL noise

## Verification
- `pnpm test`
- `pnpm type-check`
- `pnpm build`
- `npx tsc --noEmit --pretty false --project tsconfig.json`
- manual browser verification:
  - filtered-out photo detail route still opens correctly
  - command palette can open a filtered-out photo correctly
  - `/explore -> photo -> close` returns to `/explore`
  - `?lng=ja` renders Japanese strings

## Remaining risks
- map-origin close behavior still relies partly on helper/unit coverage plus manual checks
- `returnTo` is intentionally allowlisted to `/explore` only; any future origin surface must opt in explicitly
- Japanese locale compatibility is verified for `ja` and legacy `jp`, but not exhaustively across all regional variants
