### PR TITLE
ci: split major dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,14 +21,6 @@ updates:
         update-types:
           - minor
           - patch
-      production-major:
-        dependency-type: production
-        update-types:
-          - major
-      development-major:
-        dependency-type: development
-        update-types:
-          - major
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -44,8 +36,3 @@ updates:
         update-types:
           - minor
           - patch
-      actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - major


### PR DESCRIPTION
## What changed

- keep production and development minor/patch updates grouped
- stop grouping npm major updates
- stop grouping GitHub Actions major updates

## Why

Grouped major updates produced oversized pull requests that mixed unrelated breaking changes. Dependabot will now open one pull request per major dependency, making compatibility work and rollback decisions focused.

## Validation

- `pnpm exec prettier --check .github/dependabot.yml`
- `git diff --check`
