### PR TITLE
feat(web): remove attribution footer

### DIFF
--- a/apps/web/e2e/prod-smoke.spec.ts
+++ b/apps/web/e2e/prod-smoke.spec.ts
@@ -48,14 +48,6 @@ test("production bundle serves gallery, viewer route, and service worker", async
   const photoItems = page.locator("[data-photo-id]");
   await expect(photoItems.first()).toBeVisible();
   expect(await photoItems.count()).toBeGreaterThan(0);
-  await expect(
-    page.getByText("Powered by Afilmory", { exact: true }),
-  ).toBeVisible();
-  await expect(page.getByRole("link", { name: /^Source \(/ })).toHaveAttribute(
-    "href",
-    /github\.com\/vsxd\/afilmory-vercel(?:\/tree\/[^/]+)?$/,
-  );
-
   // 生产专属：manifest 以外部 hashed 资产 + 内联 fetch 脚本交付（dev server
   // 走 /__afilmory/ 中间件、内嵌模式则完全无请求）。不能断言
   // window.__AFILMORY__.manifest.mode === 'external'：manifest 加载完成后

--- a/apps/web/src/modules/gallery/MasonryHeaderMasonryItem.tsx
+++ b/apps/web/src/modules/gallery/MasonryHeaderMasonryItem.tsx
@@ -9,7 +9,7 @@ import { siteConfig } from "~/config";
 import { useContextPhotos } from "~/hooks/usePhotoViewer";
 import { MageLens, TablerAperture } from "~/icons";
 import { getPhotoGeoData } from "~/lib/geo-regions";
-import { useAfilmoryRuntime, usePhotoRepository } from "~/runtime/app-runtime";
+import { usePhotoRepository } from "~/runtime/app-runtime";
 import type { PhotoManifest } from "~/types/photo";
 
 import { ActionGroup } from "./ActionGroup";
@@ -48,7 +48,6 @@ export const MasonryHeaderMasonryItem = ({
   const gallerySetting = useAtomValue(gallerySettingAtom);
   const visiblePhotos = useContextPhotos();
   const photoRepository = usePhotoRepository();
-  const { build } = useAfilmoryRuntime().browser;
   const photos = photoRepository.getPhotos();
   const visiblePhotoCount = visiblePhotos.length;
   const githubUrl = getGitHubUrl(siteConfig.social?.github);
@@ -405,41 +404,6 @@ export const MasonryHeaderMasonryItem = ({
           </div>
         )}
       </div>
-      <footer className="border-fill-secondary text-text-tertiary border-t px-4 py-2 text-center text-[10px] leading-relaxed">
-        <span>{`Powered by ${build?.appName || "Afilmory"}`}</span>
-        {build?.sourceUrl && (
-          <span>
-            <span aria-hidden="true"> · </span>
-            <a
-              href={build.sourceUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="hover:text-text underline-offset-2 hover:underline"
-            >
-              <span>
-                {build.sourceDirty
-                  ? build.sourceExact
-                    ? `Source (v${build.version || "0.0.0"}/modified)`
-                    : `Source (v${build.version || "0.0.0"}/uncommitted; repository only)`
-                  : `Source (v${build.version || "0.0.0"}/${build.gitCommitHash?.slice(0, 8) || "source"})`}
-              </span>
-            </a>
-          </span>
-        )}
-        {build?.licenseUrl && (
-          <span>
-            <span aria-hidden="true"> · </span>
-            <a
-              href={build.licenseUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="hover:text-text underline-offset-2 hover:underline"
-            >
-              <span>License: AGPL-3.0-or-later</span>
-            </a>
-          </span>
-        )}
-      </footer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- remove the sidebar attribution footer from the gallery layout
- remove the production smoke assertions for the deleted footer

The gallery no longer renders the “Powered by Afilmory”, source, or license footer requested in the site feedback.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test` (190 files, 1203 tests)
- `SKIP_MANIFEST_BUILD=true pnpm build`
